### PR TITLE
fix(api): restaura telemetria e config token

### DIFF
--- a/servidor/api-internal/app/main.py
+++ b/servidor/api-internal/app/main.py
@@ -2016,15 +2016,6 @@ async def get_project_config_token(
     project_name = validate_project_id(project_name)
     auth_user = await resolve_authenticated_user(request, pool)
 
-    try:
-        telemetry_period = resolve_telemetry_period(
-            period,
-            start=start,
-            end=end,
-        )
-    except TelemetryValidationError as exc:
-        raise HTTPException(422, str(exc)) from exc
-
     async with pool.acquire() as conn:
         async with conn.transaction():
             project = await get_project_row(conn, project_name)
@@ -5032,6 +5023,15 @@ async def get_project_user_telemetry(
 ):
     project_name = validate_project_id(project_name)
     auth_user = await resolve_authenticated_user(request, pool)
+
+    try:
+        telemetry_period = resolve_telemetry_period(
+            period,
+            start=start,
+            end=end,
+        )
+    except TelemetryValidationError as exc:
+        raise HTTPException(422, str(exc)) from exc
 
     async with pool.acquire() as conn:
         project_row = await get_project_row(conn, project_name)

--- a/tests/smoke/test_project_telemetry.py
+++ b/tests/smoke/test_project_telemetry.py
@@ -104,5 +104,37 @@ class ProjectTelemetryTest(unittest.TestCase):
         self.assertIn('response.headers["Cache-Control"] = "no-store"', route_source)
 
 
+    def test_telemetry_route_resolves_period_before_use(self) -> None:
+        main_source = (APP_ROOT / "app" / "main.py").read_text(encoding="utf-8")
+        route_start = main_source.index(
+            '@app.get("/api/projects/{project_name}/telemetry/users")'
+        )
+        route_end = main_source.index("\n@app.api_route(", route_start)
+        route_source = main_source[route_start:route_end]
+
+        resolve_index = route_source.index(
+            "telemetry_period = resolve_telemetry_period("
+        )
+        first_use_index = route_source.index(
+            '"period": telemetry_period.key'
+        )
+        self.assertLess(resolve_index, first_use_index)
+        self.assertIn("except TelemetryValidationError as exc", route_source)
+
+    def test_config_token_route_has_no_telemetry_period_logic(self) -> None:
+        main_source = (APP_ROOT / "app" / "main.py").read_text(encoding="utf-8")
+        route_start = main_source.index(
+            '@app.get("/api/projects/{project_name}/config-token")'
+        )
+        route_end = main_source.index(
+            '\n@app.get("/api/projects/{project_name}/queue-status")',
+            route_start,
+        )
+        route_source = main_source[route_start:route_end]
+
+        self.assertNotIn("resolve_telemetry_period", route_source)
+        self.assertNotIn("telemetry_period", route_source)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Diagnóstico

Os dois erros têm a mesma causa na API Python:

- o bloco que resolve `period`, `start` e `end` foi inserido dentro do endpoint de `config-token`, onde essas variáveis não existem;
- a rota de telemetria usa `telemetry_period` sem inicializá-lo.

Isso gera `NameError` e HTTP 500 nas duas chamadas.

## Revisão ponta a ponta

- o Flutter chama `/api/projects/<ref>/config-token` corretamente;
- o Flutter chama `/api/projects/<ref>/telemetry/users?period=...` corretamente;
- o OpenResty encaminha ambas pela rota genérica de projetos com `X-Shared-Token` e `X-User-Token`;
- não é necessária alteração no Flutter nem no OpenResty.

## Correção

- remove a resolução de período do endpoint de `config-token`;
- inicializa e valida o período dentro da rota de telemetria, antes do primeiro uso;
- adiciona testes de regressão que verificam a posição do bloco e impedem que lógica de telemetria volte ao endpoint do token.

## Escopo

A alteração final fica restrita a:

- `servidor/api-internal/app/main.py`;
- `tests/smoke/test_project_telemetry.py`.

## Validação

Executado com sucesso no GitHub Actions:

- `python -m py_compile servidor/api-internal/app/main.py`;
- `python tests/smoke/test_project_telemetry.py`.

O diff final contém apenas a movimentação do bloco de resolução de período e dois testes de regressão.