### PR TITLE
fix(content): usa project id estável nos snippets

### DIFF
--- a/servidor/api-internal/app/main.py
+++ b/servidor/api-internal/app/main.py
@@ -704,6 +704,58 @@ async def audit_project_member_change(
         actor_user_id,
     )
 
+@app.get("/api/projects/internal/content-identity/{project_name}")
+async def get_content_project_identity(
+    project_name: str,
+    request: Request,
+    pool=Depends(get_pool),
+):
+    """Resolve o slug mutável para o UUID estável usado apenas por content."""
+    project_name = validate_project_id(project_name)
+    if request.headers.get("X-Internal-Service") != "studio-nginx":
+        raise HTTPException(403, "Internal service access required")
+
+    async with pool.acquire() as conn:
+        project = await conn.fetchrow(
+            "SELECT id, name FROM projects WHERE name = $1",
+            project_name,
+        )
+        if not project:
+            raise HTTPException(404, "Project not found")
+
+        history = await conn.fetch(
+            """
+            SELECT old_name, new_name
+            FROM project_name_history
+            WHERE project_id = $1
+              AND status = 'succeeded'
+            ORDER BY created_at ASC
+            """,
+            project["id"],
+        )
+
+    aliases: list[str] = []
+    seen: set[str] = set()
+    candidates = (
+        [project["name"]]
+        + [row["old_name"] for row in history]
+        + [row["new_name"] for row in history]
+    )
+    for candidate in candidates:
+        if candidate and candidate not in seen:
+            seen.add(candidate)
+            aliases.append(candidate)
+
+    return JSONResponse(
+        content={
+            "project_id": str(project["id"]),
+            "current_ref": project["name"],
+            "aliases": aliases,
+        },
+        headers={"Cache-Control": "no-store"},
+    )
+
+
 @app.get("/api/projects")
 async def list_projects(
     request: Request,

--- a/studio/nginx/lua/admin_api/snippets_rename.lua
+++ b/studio/nginx/lua/admin_api/snippets_rename.lua
@@ -1,108 +1,33 @@
--- Renomeia as pastas de snippets SQL do usuario quando um projeto muda de slug.
+-- Endpoint mantido apenas para compatibilidade com versões antigas da Projects API.
 --
--- Os snippets do Studio (SNIPPETS_MANAGEMENT_FOLDER) sao guardados em diretorios
--- nomeados "<user_id>__<slug>" (raiz) e "<user_id>__<slug>__<sub>" (subpastas).
--- Quando o projeto e renomeado, esses diretorios precisam migrar para o novo
--- slug, senao os snippets ficam orfaos e "somem" do front. O projects-api chama
--- este endpoint (mesma auth do invalidate_service_key) apos concluir o rename.
+-- O namespace atual de snippets usa o UUID estável de projects.id. Portanto,
+-- renomear o slug não deve mais alterar diretórios. A migração das pastas antigas
+-- acontece sob demanda no proxy de content, usando também project_name_history.
 local cjson = require("cjson")
 local cjson_safe = require("cjson.safe")
-local lfs = require("lfs")
 local shared_token = require("security.shared_token")
-
-local SNIPPETS_DIR = os.getenv("SNIPPETS_MANAGEMENT_FOLDER") or "/app/snippets"
-
-local function forbidden()
-    return ngx.exit(ngx.HTTP_FORBIDDEN)
-end
 
 local headers = ngx.req.get_headers()
 local supplied_token = headers["X-Shared-Token"] or ""
 local internal_service = headers["X-Internal-Service"]
 
 if internal_service ~= "projects-api" or not shared_token.matches(supplied_token) then
-    return forbidden()
+    return ngx.exit(ngx.HTTP_FORBIDDEN)
 end
 if ngx.req.get_method() ~= "POST" then
     return ngx.exit(ngx.HTTP_METHOD_NOT_ALLOWED)
 end
 
-local function valid_name(name)
-    if type(name) ~= "string" then
-        return false
-    end
-    return ngx.re.match(name, [[^[a-z_][a-z0-9_]{2,39}$]], "jo") ~= nil
-end
-
 ngx.req.read_body()
 local body = cjson_safe.decode(ngx.req.get_body_data() or "{}") or {}
-local old_name = body.old_name
-local new_name = body.new_name
-
-if not valid_name(old_name) or not valid_name(new_name) or old_name == new_name then
+if type(body.old_name) ~= "string" or type(body.new_name) ~= "string" then
     return ngx.exit(ngx.HTTP_BAD_REQUEST)
-end
-
--- Diretorio inexistente: nada a migrar (idempotente).
-if not lfs.attributes(SNIPPETS_DIR, "mode") then
-    ngx.header.content_type = "application/json"
-    ngx.say(cjson.encode({ renamed = 0, errors = {} }))
-    return
-end
-
--- Coleta primeiro; so renomeia depois de fechar o iterador do lfs.dir para nao
--- invalidar a enumeracao ao mexer no proprio diretorio.
-local planned = {}
-for entry in lfs.dir(SNIPPETS_DIR) do
-    if entry ~= "." and entry ~= ".." then
-        local full = SNIPPETS_DIR .. "/" .. entry
-        if lfs.attributes(full, "mode") == "directory" then
-            -- O user_id (UUID) nao contem "__", entao o primeiro "__" separa o
-            -- user_id do escopo ("<slug>" ou "<slug>__<sub>").
-            local _, sep_end = entry:find("__", 1, true)
-            if sep_end then
-                local prefix = entry:sub(1, sep_end)
-                local scope = entry:sub(sep_end + 1)
-                local new_scope
-                if scope == old_name then
-                    new_scope = new_name
-                elseif scope:sub(1, #old_name + 2) == old_name .. "__" then
-                    new_scope = new_name .. scope:sub(#old_name + 1)
-                end
-                if new_scope then
-                    table.insert(planned, {
-                        from = full,
-                        to = SNIPPETS_DIR .. "/" .. prefix .. new_scope,
-                        label = entry,
-                    })
-                end
-            end
-        end
-    end
-end
-
-local renamed = 0
-local errors = {}
-
-for _, item in ipairs(planned) do
-    if lfs.attributes(item.to, "mode") then
-        local message = "destino ja existe: " .. item.to
-        ngx.log(ngx.ERR, "[SNIPPETS-RENAME] ", message)
-        table.insert(errors, message)
-    else
-        local ok, err = os.rename(item.from, item.to)
-        if ok then
-            renamed = renamed + 1
-        else
-            local message = item.label .. ": " .. (err or "rename falhou")
-            ngx.log(ngx.ERR, "[SNIPPETS-RENAME] ", message)
-            table.insert(errors, message)
-        end
-    end
 end
 
 ngx.header.content_type = "application/json"
 ngx.say(cjson.encode({
-    renamed = renamed,
-    errors = setmetatable(errors, cjson.array_mt),
+    renamed = 0,
+    errors = setmetatable({}, cjson.array_mt),
+    deprecated = true,
+    message = "content namespaces are stable and no longer follow project slugs",
 }))

--- a/studio/nginx/lua/studio_compat/content_namespace_migration.lua
+++ b/studio/nginx/lua/studio_compat/content_namespace_migration.lua
@@ -1,0 +1,360 @@
+local lfs = require("lfs")
+
+local M = {}
+
+local SNIPPETS_DIR = os.getenv("SNIPPETS_MANAGEMENT_FOLDER") or "/app/snippets"
+local cache = ngx.shared.service_keys
+
+local function acquire_lock(key, timeout_seconds, exptime_seconds)
+    if not cache then
+        return function() end
+    end
+
+    local token = table.concat({
+        tostring(ngx.now()),
+        tostring(math.random()),
+        tostring(coroutine.running() or "main"),
+    }, ":")
+    local deadline = ngx.now() + timeout_seconds
+
+    repeat
+        local acquired, err = cache:add(key, token, exptime_seconds)
+        if acquired then
+            return function()
+                if cache:get(key) == token then
+                    cache:delete(key)
+                end
+            end
+        end
+        if err and err ~= "exists" then
+            return nil, err
+        end
+        ngx.sleep(0.01)
+    until ngx.now() >= deadline
+
+    return nil, "timeout"
+end
+
+local function mode(path)
+    return lfs.attributes(path, "mode")
+end
+
+local function join(left, right)
+    return left .. "/" .. right
+end
+
+local function read_file(path)
+    local file, err = io.open(path, "rb")
+    if not file then
+        return nil, err
+    end
+    local content = file:read("*a")
+    file:close()
+    return content
+end
+
+local function files_equal(left, right)
+    local left_size = lfs.attributes(left, "size")
+    local right_size = lfs.attributes(right, "size")
+    if left_size == nil or right_size == nil or left_size ~= right_size then
+        return false
+    end
+
+    local left_content = read_file(left)
+    local right_content = read_file(right)
+    return left_content ~= nil and right_content ~= nil and left_content == right_content
+end
+
+local function directory_entries(path)
+    local entries = {}
+    for entry in lfs.dir(path) do
+        if entry ~= "." and entry ~= ".." then
+            table.insert(entries, entry)
+        end
+    end
+    table.sort(entries)
+    return entries
+end
+
+local function directory_is_empty(path)
+    for entry in lfs.dir(path) do
+        if entry ~= "." and entry ~= ".." then
+            return false
+        end
+    end
+    return true
+end
+
+local function safe_label(value)
+    local label = tostring(value or "legacy"):gsub("[^%w._-]", "_")
+    if label == "" then
+        return "legacy"
+    end
+    return label
+end
+
+local function conflict_target(target_dir, filename, label, source_path)
+    local stem, extension = filename:match("^(.*)(%.[^.]*)$")
+    if not stem then
+        stem = filename
+        extension = ""
+    end
+
+    local base = stem .. "__legacy_" .. safe_label(label)
+    for index = 0, 999 do
+        local suffix = index == 0 and "" or ("_" .. tostring(index))
+        local candidate = join(target_dir, base .. suffix .. extension)
+        local candidate_mode = mode(candidate)
+        if not candidate_mode then
+            return candidate, false
+        end
+        if mode(source_path) == "file" and candidate_mode == "file"
+            and files_equal(source_path, candidate)
+        then
+            return candidate, true
+        end
+    end
+    return nil, false
+end
+
+local function move_entry(source_path, target_path, target_dir, filename, label, stats)
+    local source_mode = mode(source_path)
+    local target_mode = mode(target_path)
+    if not source_mode then
+        return true
+    end
+
+    if not target_mode then
+        local ok, err = os.rename(source_path, target_path)
+        if not ok then
+            return nil, err or "rename failed"
+        end
+        stats.moved_entries = stats.moved_entries + 1
+        return true
+    end
+
+    if source_mode == "file" and target_mode == "file" and files_equal(source_path, target_path) then
+        local ok, err = os.remove(source_path)
+        if not ok then
+            return nil, err or "failed to remove duplicate"
+        end
+        stats.identical_duplicates = stats.identical_duplicates + 1
+        return true
+    end
+
+    local preserved_path, already_preserved = conflict_target(
+        target_dir,
+        filename,
+        label,
+        source_path
+    )
+    if not preserved_path then
+        return nil, "could not allocate a conflict-safe filename"
+    end
+
+    if already_preserved then
+        local ok, err = os.remove(source_path)
+        if not ok then
+            return nil, err or "failed to remove preserved duplicate"
+        end
+        stats.identical_duplicates = stats.identical_duplicates + 1
+        return true
+    end
+
+    local ok, err = os.rename(source_path, preserved_path)
+    if not ok then
+        return nil, err or "failed to preserve conflicting entry"
+    end
+    stats.conflicts_preserved = stats.conflicts_preserved + 1
+    ngx.log(
+        ngx.WARN,
+        "[CONTENT-MIGRATION] Preserved conflicting snippet as ",
+        preserved_path
+    )
+    return true
+end
+
+local function merge_directory(source, target, label, stats)
+    if mode(source) ~= "directory" then
+        return true
+    end
+
+    local target_mode = mode(target)
+    if not target_mode then
+        local ok, err = os.rename(source, target)
+        if not ok then
+            return nil, err or "directory rename failed"
+        end
+        stats.renamed_directories = stats.renamed_directories + 1
+        return true
+    end
+    if target_mode ~= "directory" then
+        return nil, "namespace target exists and is not a directory: " .. target
+    end
+
+    for _, entry in ipairs(directory_entries(source)) do
+        local source_path = join(source, entry)
+        local target_path = join(target, entry)
+        local ok, err = move_entry(
+            source_path,
+            target_path,
+            target,
+            entry,
+            label,
+            stats
+        )
+        if not ok then
+            return nil, source_path .. ": " .. (err or "merge failed")
+        end
+    end
+
+    if directory_is_empty(source) then
+        local ok, err = lfs.rmdir(source)
+        if not ok then
+            return nil, err or ("failed to remove empty legacy directory " .. source)
+        end
+        stats.removed_directories = stats.removed_directories + 1
+    end
+
+    return true
+end
+
+local function collect_plans(user_id, project_id, aliases)
+    local plans = {}
+    local seen_sources = {}
+    local target_root_name = user_id .. "__" .. project_id
+
+    if mode(SNIPPETS_DIR) ~= "directory" then
+        return plans
+    end
+
+    local top_level = directory_entries(SNIPPETS_DIR)
+    for _, alias in ipairs(aliases or {}) do
+        if alias ~= project_id then
+            local legacy_root_name = user_id .. "__" .. alias
+            local legacy_prefix = legacy_root_name .. "__"
+
+            for _, entry in ipairs(top_level) do
+                local target_name
+                if entry == legacy_root_name then
+                    target_name = target_root_name
+                elseif entry:sub(1, #legacy_prefix) == legacy_prefix then
+                    target_name = target_root_name .. "__" .. entry:sub(#legacy_prefix + 1)
+                end
+
+                if target_name and not seen_sources[entry] then
+                    local source = join(SNIPPETS_DIR, entry)
+                    if mode(source) == "directory" then
+                        seen_sources[entry] = true
+                        table.insert(plans, {
+                            source = source,
+                            target = join(SNIPPETS_DIR, target_name),
+                            alias = alias,
+                        })
+                    end
+                end
+            end
+        end
+    end
+
+    table.sort(plans, function(left, right)
+        return left.source < right.source
+    end)
+    return plans
+end
+
+local function migration_marker(user_id, identity)
+    return table.concat({
+        "content:namespace-migrated",
+        user_id,
+        identity.project_id,
+        identity.current_ref,
+    }, ":")
+end
+
+function M.ensure(user_id, identity)
+    if not user_id or user_id == "" then
+        return nil, "user id is missing"
+    end
+    if type(identity) ~= "table" or not identity.project_id then
+        return nil, "project identity is missing"
+    end
+
+    local marker = migration_marker(user_id, identity)
+    if cache and cache:get(marker) then
+        return true
+    end
+
+    if mode(SNIPPETS_DIR) ~= "directory" then
+        if cache then
+            cache:set(marker, true, 30)
+        end
+        return true
+    end
+
+    local release_lock, lock_err = acquire_lock(marker .. ":lock", 2, 10)
+    if not release_lock then
+        return nil, "failed to acquire migration lock: " .. (lock_err or "timeout")
+    end
+
+    if cache and cache:get(marker) then
+        release_lock()
+        return true
+    end
+
+    local stats = {
+        renamed_directories = 0,
+        removed_directories = 0,
+        moved_entries = 0,
+        identical_duplicates = 0,
+        conflicts_preserved = 0,
+    }
+
+    local ok = true
+    local failure
+    for _, plan in ipairs(collect_plans(user_id, identity.project_id, identity.aliases)) do
+        local merged, merge_err = merge_directory(
+            plan.source,
+            plan.target,
+            plan.alias,
+            stats
+        )
+        if not merged then
+            ok = false
+            failure = merge_err or "namespace merge failed"
+            break
+        end
+    end
+
+    if ok and cache then
+        cache:set(marker, true, 30)
+    end
+
+    release_lock()
+
+    if not ok then
+        return nil, failure
+    end
+
+    if stats.renamed_directories > 0
+        or stats.removed_directories > 0
+        or stats.moved_entries > 0
+        or stats.identical_duplicates > 0
+        or stats.conflicts_preserved > 0
+    then
+        ngx.log(
+            ngx.NOTICE,
+            "[CONTENT-MIGRATION] user=", user_id,
+            " project_id=", identity.project_id,
+            " renamed_dirs=", stats.renamed_directories,
+            " removed_dirs=", stats.removed_directories,
+            " moved_entries=", stats.moved_entries,
+            " identical=", stats.identical_duplicates,
+            " conflicts_preserved=", stats.conflicts_preserved
+        )
+    end
+
+    return true, stats
+end
+
+return M

--- a/studio/nginx/lua/studio_compat/content_project_identity.lua
+++ b/studio/nginx/lua/studio_compat/content_project_identity.lua
@@ -1,0 +1,137 @@
+local cjson = require("cjson.safe")
+local http = require("resty.http")
+
+local M = {}
+
+local SERVER_DOMAIN = (os.getenv("SERVER_DOMAIN") or ""):gsub("/+$", "")
+local SERVER_HOSTNAME = string.match(SERVER_DOMAIN, "//([^/:]+)") or "localhost"
+local SHARED_TOKEN = os.getenv("NGINX_SHARED_TOKEN") or ""
+local CACHE_TTL_SECONDS = 30
+local cache = ngx.shared.service_keys
+
+local function valid_project_ref(value)
+    return type(value) == "string"
+        and ngx.re.match(value, [[^[a-z_][a-z0-9_]{2,39}$]], "jo") ~= nil
+end
+
+local function valid_uuid(value)
+    return type(value) == "string"
+        and ngx.re.match(
+            value,
+            [[^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$]],
+            "jo"
+        ) ~= nil
+end
+
+local function cache_key(project_ref)
+    return "content:project-identity:" .. project_ref
+end
+
+local function normalize_identity(payload, requested_ref)
+    if type(payload) ~= "table" then
+        return nil, "invalid identity payload"
+    end
+
+    local project_id = tostring(payload.project_id or ""):lower()
+    if not valid_uuid(project_id) then
+        return nil, "invalid stable project id"
+    end
+
+    local current_ref = payload.current_ref
+    if not valid_project_ref(current_ref) then
+        current_ref = requested_ref
+    end
+
+    local aliases = {}
+    local seen = {}
+    local function append(value)
+        if valid_project_ref(value) and not seen[value] then
+            seen[value] = true
+            table.insert(aliases, value)
+        end
+    end
+
+    append(current_ref)
+    append(requested_ref)
+    for _, value in ipairs(payload.aliases or {}) do
+        append(value)
+    end
+
+    return {
+        project_id = project_id,
+        current_ref = current_ref,
+        aliases = aliases,
+    }
+end
+
+local function fetch_identity(project_ref)
+    if SERVER_DOMAIN == "" or SHARED_TOKEN == "" then
+        return nil, "content identity configuration is missing"
+    end
+
+    local client = http.new()
+    client:set_timeout(2000)
+    local response, err = client:request_uri(
+        SERVER_DOMAIN
+            .. "/api/projects/internal/content-identity/"
+            .. ngx.escape_uri(project_ref),
+        {
+            method = "GET",
+            headers = {
+                ["Accept"] = "application/json",
+                ["Host"] = SERVER_HOSTNAME,
+                ["X-Shared-Token"] = SHARED_TOKEN,
+                ["X-Internal-Service"] = "studio-nginx",
+            },
+            ssl_verify = false,
+            keepalive = true,
+        }
+    )
+
+    if not response then
+        return nil, "content identity request failed: " .. (err or "unknown error")
+    end
+    if response.status ~= ngx.HTTP_OK then
+        return nil, "content identity returned HTTP " .. tostring(response.status)
+    end
+
+    local decoded, decode_err = cjson.decode(response.body or "")
+    if not decoded then
+        return nil, "content identity JSON is invalid: " .. (decode_err or "decode failed")
+    end
+    return normalize_identity(decoded, project_ref)
+end
+
+function M.resolve(project_ref)
+    if not valid_project_ref(project_ref) then
+        return nil, "invalid selected project ref"
+    end
+
+    if cache then
+        local cached = cache:get(cache_key(project_ref))
+        if cached then
+            local decoded = cjson.decode(cached)
+            local identity = decoded and normalize_identity(decoded, project_ref)
+            if identity then
+                return identity
+            end
+            cache:delete(cache_key(project_ref))
+        end
+    end
+
+    local identity, err = fetch_identity(project_ref)
+    if not identity then
+        return nil, err
+    end
+
+    if cache then
+        local encoded = cjson.encode(identity)
+        if encoded then
+            cache:set(cache_key(project_ref), encoded, CACHE_TTL_SECONDS)
+        end
+    end
+
+    return identity
+end
+
+return M

--- a/studio/nginx/lua/studio_compat/content_user_proxy.lua
+++ b/studio/nginx/lua/studio_compat/content_user_proxy.lua
@@ -3,6 +3,8 @@ local cjson = require("cjson")
 local cjson_safe = require("cjson.safe")
 local http = require("resty.http")
 local user_identity = require("project_context.user_identity")
+local content_project_identity = require("studio_compat.content_project_identity")
+local content_namespace_migration = require("studio_compat.content_namespace_migration")
 
 local _M = {}
 
@@ -34,24 +36,39 @@ local function get_project_ref()
     return ngx.var.uri:match("^/api/platform/projects/([^/]+)/content")
 end
 
-local function get_project_scope()
+local function get_selected_project_ref()
     local project_ref = ngx.var.project_ref
     if project_ref and project_ref ~= "" and project_ref ~= "default" then
         return project_ref
     end
-
     return nil
 end
 
 local function require_project_scope()
-    local project_scope = get_project_scope()
-    if project_scope then
-        return project_scope
+    local selected_ref = get_selected_project_ref()
+    if not selected_ref then
+        return respond_json(403, {
+            error = {
+                message = "Selecione um projeto antes de acessar snippets.",
+            },
+        })
     end
 
-    return respond_json(403, {
+    local identity, identity_err = content_project_identity.resolve(selected_ref)
+    if identity then
+        return identity.project_id
+    end
+
+    ngx.log(
+        ngx.ERR,
+        "[CONTENT-PROXY] Failed to resolve stable project identity for ",
+        selected_ref,
+        ": ",
+        identity_err or "unknown error"
+    )
+    return respond_json(502, {
         error = {
-            message = "Selecione um projeto antes de acessar snippets.",
+            message = "Failed to resolve stable project identity",
         },
     })
 end
@@ -396,6 +413,15 @@ local function build_folder_aliases(user_id, project_scope, folder, visible_name
     local seen = {}
 
     append_unique(aliases, seen, virtual_folder_id(user_id, project_scope, visible_name))
+
+    local selected_ref = get_selected_project_ref()
+    local identity = selected_ref and content_project_identity.resolve(selected_ref) or nil
+    for _, legacy_scope in ipairs((identity and identity.aliases) or {}) do
+        if legacy_scope ~= project_scope then
+            append_unique(aliases, seen, virtual_folder_id(user_id, legacy_scope, visible_name))
+        end
+    end
+
     append_unique(aliases, seen, virtual_folder_id(user_id, "default", visible_name))
     append_unique(aliases, seen, deterministic_uuid({ visible_name }))
 
@@ -422,7 +448,7 @@ local function to_virtual_snippet(snippet, virtual_id, virtual_folder_id)
     return cloned
 end
 
-local function resolve_virtual_snippet_id(project_ref, user_id, snippet, virtual_folder_id)
+local function resolve_virtual_snippet_id(project_ref, user_id, snippet, virtual_folder_id, id_namespace)
     if type(snippet) ~= "table" or not snippet.id or snippet.id == "" then
         return nil
     end
@@ -433,7 +459,7 @@ local function resolve_virtual_snippet_id(project_ref, user_id, snippet, virtual
         return preferred
     end
 
-    local canonical = virtual_snippet_id(snippet.name or "", virtual_folder_id)
+    local canonical = virtual_snippet_id(snippet.name or "", id_namespace or virtual_folder_id)
     set_mapped_actual_id(project_ref, user_id, canonical, snippet.id, false)
     return canonical
 end
@@ -563,6 +589,17 @@ local function load_namespace_state(project_ref, user_id, project_scope)
 end
 
 local function resolve_namespace_root_folder(project_ref, user_id, project_scope, create_if_missing)
+    local selected_ref = get_selected_project_ref()
+    local identity, identity_err = content_project_identity.resolve(selected_ref)
+    if not identity or identity.project_id ~= project_scope then
+        return nil, nil, identity_err or "stable project identity mismatch"
+    end
+
+    local migrated, migration_err = content_namespace_migration.ensure(user_id, identity)
+    if not migrated then
+        return nil, nil, "legacy namespace migration failed: " .. (migration_err or "unknown error")
+    end
+
     local state, state_err = load_namespace_state(project_ref, user_id, project_scope)
     if not state then
         return nil, nil, state_err
@@ -725,7 +762,18 @@ end
 
 local function virtualize_snippet(scope_key, user_id, namespace_state, snippet, forced_virtual_id)
     local virtual_folder = resolve_virtual_folder_id_for_snippet(namespace_state, snippet)
-    local virtual_id = forced_virtual_id or resolve_virtual_snippet_id(scope_key, user_id, snippet, virtual_folder)
+    local id_namespace = virtual_folder
+    if not id_namespace and namespace_state.root_folder then
+        id_namespace = namespace_state.root_folder.id
+    end
+    local virtual_id = forced_virtual_id
+        or resolve_virtual_snippet_id(
+            scope_key,
+            user_id,
+            snippet,
+            virtual_folder,
+            id_namespace
+        )
     return to_virtual_snippet(snippet, virtual_id, virtual_folder)
 end
 
@@ -790,10 +838,36 @@ local function find_actual_snippet_in_collection(scope_key, user_id, request_id,
 
     for _, snippet in ipairs(snippets or {}) do
         local virtual_folder = resolve_virtual_folder_id_for_snippet(namespace_state, snippet)
-        local canonical_id = virtual_snippet_id(snippet.name, virtual_folder)
-        local visible_id = resolve_virtual_snippet_id(scope_key, user_id, snippet, virtual_folder)
+        local id_namespace = virtual_folder
+        if not id_namespace and namespace_state.root_folder then
+            id_namespace = namespace_state.root_folder.id
+        end
 
-        if snippet.id == request_id or canonical_id == request_id or visible_id == request_id then
+        local canonical_id = virtual_snippet_id(snippet.name, id_namespace)
+        local visible_id = resolve_virtual_snippet_id(
+            scope_key,
+            user_id,
+            snippet,
+            virtual_folder,
+            id_namespace
+        )
+        local legacy_id = virtual_snippet_id(snippet.name, virtual_folder)
+        local matches = snippet.id == request_id
+            or canonical_id == request_id
+            or visible_id == request_id
+            or legacy_id == request_id
+
+        if not matches and snippet.folder_id and snippet.folder_id ~= cjson.null then
+            local folder_entry = namespace_state.child_by_actual_id[snippet.folder_id]
+            for _, alias in ipairs((folder_entry and folder_entry.aliases) or {}) do
+                if virtual_snippet_id(snippet.name, alias) == request_id then
+                    matches = true
+                    break
+                end
+            end
+        end
+
+        if matches then
             set_mapped_actual_id(scope_key, user_id, request_id, snippet.id, visible_id == request_id)
             return snippet
         end
@@ -981,7 +1055,7 @@ function _M.handle_content()
         end
 
         local root_folder, namespace_state, folder_err =
-            resolve_namespace_root_folder(api_project_ref, user_id, project_scope, true)
+            resolve_namespace_root_folder(api_project_ref, user_id, project_scope, false)
         if not root_folder then
             ngx.log(ngx.ERR, "[CONTENT-PROXY] Failed to resolve user folder: ", folder_err or "unknown error")
             return respond_json(500, { error = { message = "Failed to resolve user folder" } })
@@ -1038,7 +1112,21 @@ function _M.handle_content()
 
         local incoming_id = payload.id
         local requested_virtual_folder_id = payload.folder_id
-        local canonical_virtual_id = virtual_snippet_id(payload.name or "", requested_virtual_folder_id)
+        local target_folder = resolve_actual_folder(
+            project_scope,
+            user_id,
+            namespace_state,
+            requested_virtual_folder_id
+        )
+        if not target_folder then
+            return respond_json(404, { error = { message = "Folder not found" } })
+        end
+
+        local id_namespace = requested_virtual_folder_id
+        if id_namespace == nil or id_namespace == cjson.null or id_namespace == "" then
+            id_namespace = target_folder.id
+        end
+        local canonical_virtual_id = virtual_snippet_id(payload.name or "", id_namespace)
         local existing = resolve_actual_snippet(
             api_project_ref,
             namespace_state,
@@ -1054,11 +1142,6 @@ function _M.handle_content()
                 user_id,
                 canonical_virtual_id
             )
-        end
-
-        local target_folder = resolve_actual_folder(project_scope, user_id, namespace_state, requested_virtual_folder_id)
-        if not target_folder then
-            return respond_json(404, { error = { message = "Folder not found" } })
         end
 
         if existing then
@@ -1186,7 +1269,7 @@ function _M.handle_folders()
         end
 
         local root_folder, namespace_state, folder_err =
-            resolve_namespace_root_folder(api_project_ref, user_id, project_scope, true)
+            resolve_namespace_root_folder(api_project_ref, user_id, project_scope, false)
         if not root_folder then
             ngx.log(ngx.ERR, "[CONTENT-PROXY] Failed to resolve user folder for folders route: ", folder_err or "unknown error")
             return respond_json(500, { error = { message = "Failed to resolve user folder" } })
@@ -1374,7 +1457,7 @@ function _M.handle_count()
     end
 
     local _, namespace_state, folder_err =
-        resolve_namespace_root_folder(api_project_ref, user_id, project_scope, true)
+        resolve_namespace_root_folder(api_project_ref, user_id, project_scope, false)
     if not namespace_state then
         ngx.log(ngx.ERR, "[CONTENT-PROXY] Failed to resolve user folder for count route: ", folder_err or "unknown error")
         return respond_json(500, { error = { message = "Failed to resolve user folder" } })

--- a/tests/smoke/test_content_namespace_migration.lua
+++ b/tests/smoke/test_content_namespace_migration.lua
@@ -1,0 +1,131 @@
+local lfs = require("lfs")
+
+local root = assert(os.getenv("SNIPPETS_TEST_DIR"), "SNIPPETS_TEST_DIR is required")
+local user_id = "5dae1152-7b44-4351-8dab-5e08574dcba4"
+local project_id = "26cb6971-f9ef-4890-a924-92179b97f189"
+
+local values = {}
+local expirations = {}
+local now = 1000
+local cache = {}
+
+function cache:get(key)
+    local expires = expirations[key]
+    if expires and expires <= now then
+        values[key] = nil
+        expirations[key] = nil
+    end
+    return values[key]
+end
+
+function cache:set(key, value, ttl)
+    values[key] = value
+    expirations[key] = ttl and (now + ttl) or nil
+    return true
+end
+
+function cache:add(key, value, ttl)
+    if self:get(key) ~= nil then
+        return nil, "exists"
+    end
+    return self:set(key, value, ttl)
+end
+
+function cache:delete(key)
+    values[key] = nil
+    expirations[key] = nil
+    return true
+end
+
+ngx = {
+    shared = { service_keys = cache },
+    WARN = "WARN",
+    NOTICE = "NOTICE",
+    now = function() return now end,
+    sleep = function(seconds) now = now + seconds end,
+    log = function(...) end,
+}
+
+package.path = table.concat({
+    "studio/nginx/lua/?.lua",
+    "studio/nginx/lua/?/init.lua",
+    package.path,
+}, ";")
+
+local function join(left, right)
+    return left .. "/" .. right
+end
+
+local function mkdir(path)
+    local ok, err = lfs.mkdir(path)
+    assert(ok or lfs.attributes(path, "mode") == "directory", err)
+end
+
+local function write(path, content)
+    local file = assert(io.open(path, "wb"))
+    file:write(content)
+    file:close()
+end
+
+local function read(path)
+    local file = assert(io.open(path, "rb"))
+    local content = file:read("*a")
+    file:close()
+    return content
+end
+
+local old_root = join(root, user_id .. "__meu_projeto")
+local new_root = join(root, user_id .. "__outro_projeto")
+local old_child = join(root, user_id .. "__meu_projeto__relatorios")
+local new_child = join(root, user_id .. "__outro_projeto__relatorios")
+local stable_root = join(root, user_id .. "__" .. project_id)
+local stable_child = join(root, user_id .. "__" .. project_id .. "__relatorios")
+
+mkdir(old_root)
+mkdir(new_root)
+mkdir(old_child)
+mkdir(new_child)
+
+write(join(old_root, "query.sql"), "select 'old';\n")
+write(join(new_root, "query.sql"), "select 'new';\n")
+write(join(old_root, "same.sql"), "select 1;\n")
+write(join(new_root, "same.sql"), "select 1;\n")
+write(join(old_child, "child.sql"), "select 'old child';\n")
+write(join(new_child, "child.sql"), "select 'new child';\n")
+
+local migration = require("studio_compat.content_namespace_migration")
+local ok, stats = migration.ensure(user_id, {
+    project_id = project_id,
+    current_ref = "outro_projeto",
+    aliases = { "outro_projeto", "meu_projeto" },
+})
+assert(ok, stats)
+
+assert(lfs.attributes(stable_root, "mode") == "directory")
+assert(lfs.attributes(stable_child, "mode") == "directory")
+assert(lfs.attributes(old_root, "mode") == nil)
+assert(lfs.attributes(new_root, "mode") == nil)
+assert(lfs.attributes(old_child, "mode") == nil)
+assert(lfs.attributes(new_child, "mode") == nil)
+
+assert(read(join(stable_root, "query.sql")) == "select 'old';\n")
+assert(read(join(stable_root, "query__legacy_outro_projeto.sql")) == "select 'new';\n")
+assert(read(join(stable_root, "same.sql")) == "select 1;\n")
+assert(lfs.attributes(join(stable_root, "same__legacy_outro_projeto.sql"), "mode") == nil)
+assert(read(join(stable_child, "child.sql")) == "select 'old child';\n")
+assert(
+    read(join(stable_child, "child__legacy_outro_projeto.sql"))
+        == "select 'new child';\n"
+)
+assert(stats.conflicts_preserved == 2)
+assert(stats.identical_duplicates == 1)
+
+local second_ok, second_stats = migration.ensure(user_id, {
+    project_id = project_id,
+    current_ref = "outro_projeto",
+    aliases = { "outro_projeto", "meu_projeto" },
+})
+assert(second_ok)
+assert(second_stats == nil)
+
+print("content namespace migration test passed")

--- a/tests/smoke/test_content_stable_project_identity.py
+++ b/tests/smoke/test_content_stable_project_identity.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+import pathlib
+import unittest
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+
+
+class ContentStableProjectIdentityTests(unittest.TestCase):
+    def test_internal_identity_route_returns_project_id_and_history(self) -> None:
+        source = (ROOT / "servidor/api-internal/app/main.py").read_text(encoding="utf-8")
+        start = source.index(
+            '@app.get("/api/projects/internal/content-identity/{project_name}")'
+        )
+        end = source.index('@app.get("/api/projects")', start)
+        route = source[start:end]
+
+        self.assertIn('request.headers.get("X-Internal-Service") != "studio-nginx"', route)
+        self.assertIn('"SELECT id, name FROM projects WHERE name = $1"', route)
+        self.assertIn("FROM project_name_history", route)
+        self.assertIn('"project_id": str(project["id"])', route)
+        self.assertIn('headers={"Cache-Control": "no-store"}', route)
+
+    def test_content_proxy_uses_stable_identity_only_for_content(self) -> None:
+        source = (
+            ROOT / "studio/nginx/lua/studio_compat/content_user_proxy.lua"
+        ).read_text(encoding="utf-8")
+
+        self.assertIn('content_project_identity.resolve(selected_ref)', source)
+        self.assertIn('return identity.project_id', source)
+        self.assertIn('content_namespace_migration.ensure(user_id, identity)', source)
+        self.assertIn('id_namespace = namespace_state.root_folder.id', source)
+        self.assertIn('local legacy_id = virtual_snippet_id(snippet.name, virtual_folder)', source)
+
+    def test_read_routes_do_not_create_namespace_directories(self) -> None:
+        source = (
+            ROOT / "studio/nginx/lua/studio_compat/content_user_proxy.lua"
+        ).read_text(encoding="utf-8")
+
+        content = source[
+            source.index("function _M.handle_content()"):
+            source.index("function _M.handle_folders()")
+        ]
+        folders = source[
+            source.index("function _M.handle_folders()"):
+            source.index("function _M.handle_folder_item()")
+        ]
+        count = source[
+            source.index("function _M.handle_count()"):
+            source.index("function _M.handle_item()")
+        ]
+
+        self.assertIn(
+            "resolve_namespace_root_folder(api_project_ref, user_id, project_scope, false)",
+            content,
+        )
+        self.assertIn(
+            "resolve_namespace_root_folder(api_project_ref, user_id, project_scope, false)",
+            folders,
+        )
+        self.assertIn(
+            "resolve_namespace_root_folder(api_project_ref, user_id, project_scope, false)",
+            count,
+        )
+
+    def test_legacy_migration_preserves_conflicting_sql(self) -> None:
+        source = (
+            ROOT / "studio/nginx/lua/studio_compat/content_namespace_migration.lua"
+        ).read_text(encoding="utf-8")
+
+        self.assertIn("cache:add(key, token, exptime_seconds)", source)
+        self.assertIn('"__legacy_" .. safe_label(label)', source)
+        self.assertIn("files_equal(source_path, target_path)", source)
+        self.assertIn("stats.conflicts_preserved", source)
+        self.assertIn("identity.aliases", source)
+
+    def test_rename_endpoint_no_longer_moves_slug_directories(self) -> None:
+        source = (
+            ROOT / "studio/nginx/lua/admin_api/snippets_rename.lua"
+        ).read_text(encoding="utf-8")
+
+        self.assertIn("deprecated = true", source)
+        self.assertNotIn("os.rename", source)
+        self.assertNotIn("lfs.dir", source)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Problema

Os snippets privados eram separados fisicamente por `<user_uuid>__<project_slug>`. Como o slug muda durante o rename, o lifecycle precisava renomear diretórios no Studio. Isso permitia pastas órfãs, destino vazio criado por GET, colisões e SQLs aparentemente desaparecendo do frontend.

Também havia colisão de IDs virtuais para arquivos de mesmo nome na raiz de projetos diferentes.

## Escopo acordado

A mudança é restrita ao fluxo de `content`/SQL snippets.

- o Studio continua em `/project/default`;
- as demais rotas e integrações continuam usando o slug atual;
- somente o namespace físico e os IDs virtuais de `content` usam o UUID estável de `projects.id`.

## Implementação

- adiciona endpoint interno `slug -> projects.id`, acessível somente pelo Studio Nginx;
- devolve também aliases de rename bem-sucedidos em `project_name_history`;
- resolve e mantém a identidade por 30 segundos no OpenResty;
- passa a usar `<user_uuid>__<projects.id>` como pasta raiz dos snippets;
- inclui o namespace estável nos IDs virtuais, inclusive para arquivos na raiz;
- deixa de criar diretórios durante GET de content, folders e count;
- migra automaticamente pastas antigas por slug no primeiro acesso;
- usa lock no shared dict já existente, sem adicionar dependência Lua ao container;
- mescla diretórios existentes sem sobrescrever SQL;
- remove duplicatas idênticas e preserva conflitos como `__legacy_<slug>`;
- transforma o endpoint antigo de rename de snippets em no-op autenticado, mantendo compatibilidade com a Projects API atual.

## Migração

A migração é lazy e por usuário/projeto. Ao abrir o SQL Editor, o OpenResty consulta o ID estável e procura diretórios do slug atual e dos slugs históricos. Caso já exista o destino estável, os conteúdos são mesclados.

## Validação

Executado com sucesso:

- `python -m py_compile servidor/api-internal/app/main.py`;
- `python tests/smoke/test_content_stable_project_identity.py`;
- `luac5.1 -p` nos arquivos Lua afetados;
- teste funcional de filesystem com dois slugs, arquivos idênticos, conflitos na raiz e conflitos em subpastas;
- segunda execução idempotente da migração.

A branch está baseada na `main` após o merge da correção de telemetria/config token e possui um único commit funcional.