### PR TITLE
fix(studio): corrige permissões do volume de snippets

### DIFF
--- a/studio/docker-compose.yml
+++ b/studio/docker-compose.yml
@@ -30,6 +30,8 @@ services:
     networks: [default, rede-supabase]
     env_file:
       - .env
+    environment:
+      SNIPPETS_MANAGEMENT_FOLDER: /app/snippets
     volumes:
       - ./nginx/nginx.conf:/usr/local/openresty/nginx/conf/nginx.conf:ro
       - ./authelia:/config

--- a/studio/nginx/docker-entrypoint.sh
+++ b/studio/nginx/docker-entrypoint.sh
@@ -38,4 +38,24 @@ done
 
 chmod 755 /config/ssl 2>/dev/null || true
 
+# O Studio e o OpenResty compartilham o mesmo bind mount de snippets, mas rodam
+# com usuarios diferentes. A migracao de namespaces precisa renomear diretorios
+# criados anteriormente pelo Studio; apenas montar o volume como rw nao concede
+# essa permissao ao worker nobody.
+SNIPPETS_DIR="${SNIPPETS_MANAGEMENT_FOLDER:-/app/snippets}"
+if [ -d "$SNIPPETS_DIR" ]; then
+    chown -R 65534:65534 "$SNIPPETS_DIR" 2>/dev/null || true
+
+    # Diretorios precisam de write+execute para rename/delete e arquivos precisam
+    # continuar gravaveis pelo Studio, independentemente do UID usado pela imagem.
+    if find "$SNIPPETS_DIR" -type d -exec chmod 777 {} + \
+        && find "$SNIPPETS_DIR" -type f -exec chmod 666 {} +; then
+        echo "[entrypoint] snippets preparados para escrita compartilhada em $SNIPPETS_DIR"
+    else
+        echo "[entrypoint] WARN: não consegui preparar $SNIPPETS_DIR; a migração de snippets pode falhar"
+    fi
+else
+    echo "[entrypoint] WARN: diretório de snippets ausente: $SNIPPETS_DIR"
+fi
+
 exec openresty -g "daemon off;"

--- a/tests/smoke/test_studio_snippets_permissions.py
+++ b/tests/smoke/test_studio_snippets_permissions.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import pathlib
+import unittest
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+
+
+class StudioSnippetsPermissionsTests(unittest.TestCase):
+    def test_entrypoint_prepares_shared_snippets_before_openresty(self) -> None:
+        source = (
+            ROOT / "studio" / "nginx" / "docker-entrypoint.sh"
+        ).read_text(encoding="utf-8")
+
+        snippets_index = source.index(
+            'SNIPPETS_DIR="${SNIPPETS_MANAGEMENT_FOLDER:-/app/snippets}"'
+        )
+        openresty_index = source.index('exec openresty -g "daemon off;"')
+
+        self.assertLess(snippets_index, openresty_index)
+        self.assertIn('chown -R 65534:65534 "$SNIPPETS_DIR"', source)
+        self.assertIn(
+            'find "$SNIPPETS_DIR" -type d -exec chmod 777 {} +',
+            source,
+        )
+        self.assertIn(
+            'find "$SNIPPETS_DIR" -type f -exec chmod 666 {} +',
+            source,
+        )
+
+    def test_nginx_and_studio_share_the_same_snippets_path(self) -> None:
+        compose = (ROOT / "studio" / "docker-compose.yml").read_text(
+            encoding="utf-8"
+        )
+        nginx_start = compose.index("  nginx:\n")
+        studio_start = compose.index("  studio:\n", nginx_start)
+        nginx_block = compose[nginx_start:studio_start]
+        studio_block = compose[studio_start:]
+
+        self.assertIn("SNIPPETS_MANAGEMENT_FOLDER: /app/snippets", nginx_block)
+        self.assertIn("SNIPPETS_MANAGEMENT_FOLDER: /app/snippets", studio_block)
+        self.assertIn("- ./snippets:/app/snippets", nginx_block)
+        self.assertIn("- ./snippets:/app/snippets", studio_block)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Problema

Depois da migração de snippets para o namespace estável por `projects.id`, o OpenResty passou a renomear pastas antigas no primeiro acesso. O bind mount `./snippets:/app/snippets` era compartilhado com o Studio, mas os diretórios existentes pertenciam a outro UID. Os workers do OpenResty rodam como `nobody`, então a migração falhava com `Permission denied` e as rotas `folders`, `count` e `PUT content` retornavam `Failed to resolve user folder`.

## Correção

- declara explicitamente `SNIPPETS_MANAGEMENT_FOLDER=/app/snippets` também no serviço `nginx`;
- antes de iniciar o OpenResty, prepara recursivamente o bind mount compartilhado;
- diretórios recebem `777`, necessário para rename/delete entre UIDs diferentes;
- arquivos recebem `666`, sem adicionar permissão de execução;
- mantém o startup tolerante a volumes read-only e registra aviso claro no log;
- adiciona teste de regressão garantindo que a preparação ocorre antes do `exec openresty` e que Studio/Nginx usam o mesmo caminho.

## Impacto

A mudança não altera o namespace, os IDs virtuais ou a lógica de migração da PR #6. Ela corrige somente a permissão do armazenamento compartilhado que impedia a migração de acontecer.

## Validação

Executado localmente sobre os arquivos da branch:

- `sh -n studio/nginx/docker-entrypoint.sh`;
- parse de `studio/docker-compose.yml`;
- `python tests/smoke/test_studio_snippets_permissions.py`.

Todos passaram.

## Recuperação imediata antes do deploy

No host atual, a mesma correção pode ser aplicada sem rebuild:

```bash
docker exec -u 0 nginx sh -c '
  chown -R 65534:65534 /app/snippets 2>/dev/null || true
  find /app/snippets -type d -exec chmod 777 {} +
  find /app/snippets -type f -exec chmod 666 {} +
'
docker restart nginx
```
