### PR TITLE
fix(profile): evita timeout da API no carregamento do Studio

### DIFF
--- a/studio/nginx/lua/admin_api/user_profile_handler.lua
+++ b/studio/nginx/lua/admin_api/user_profile_handler.lua
@@ -82,10 +82,6 @@ function M.handle()
         if not profile then
             return respond(500, { error = err or "failed to load profile" })
         end
-        local _, sync_err = sync_profile(profile)
-        if sync_err then
-            ngx.log(ngx.WARN, "[USER_PROFILE] profile projection sync failed: ", sync_err)
-        end
         return respond(200, profile)
     end
 

--- a/studio/nginx/lua/admin_api/user_sync.lua
+++ b/studio/nginx/lua/admin_api/user_sync.lua
@@ -1,50 +1,66 @@
 local cjson = require("cjson.safe")
 local http = require("resty.http")
 
-local DSN = os.getenv("SERVER_DOMAIN") or ""
+local EXTERNAL_DSN = (os.getenv("SERVER_DOMAIN") or ""):gsub("/+$", "")
+local INTERNAL_DSN = (os.getenv("PROJECTS_API_INTERNAL_URL") or ""):gsub("/+$", "")
 local TOKEN = os.getenv("NGINX_SHARED_TOKEN") or ""
-local HOST = string.match(DSN, "//([^/:]+)") or "localhost"
+
+if INTERNAL_DSN == "" then
+    INTERNAL_DSN = "http://projects-api:18000"
+end
 
 local M = {}
 
-function M.sync_user(payload)
-    if DSN == "" or TOKEN == "" then
-        return nil, "SERVER_DOMAIN ou NGINX_SHARED_TOKEN ausente"
-    end
-
+local function request_sync(origin, body)
+    local host = string.match(origin, "//([^/:]+)") or "localhost"
     local httpc = http.new()
-    httpc:set_timeout(2000)
+    httpc:set_timeout(3000)
+
+    return httpc:request_uri(
+        origin .. "/api/projects/internal/users/sync",
+        {
+            method = "POST",
+            body = body,
+            ssl_verify = false,
+            headers = {
+                ["Content-Type"] = "application/json",
+                ["X-Shared-Token"] = TOKEN,
+                ["Host"] = host,
+                ["User-Agent"] = "studio-nginx-internal/1.0",
+            }
+        }
+    )
+end
+
+function M.sync_user(payload)
+    if TOKEN == "" then
+        return nil, "NGINX_SHARED_TOKEN ausente"
+    end
 
     local body = cjson.encode(payload)
     if not body then
         return nil, "falha ao serializar payload"
     end
 
-    local res, err = httpc:request_uri(
-        DSN .. "/api/projects/internal/users/sync",
-        {
-            method = "POST",
-            body = body,
-            ssl_verify = false,
-            keepalive = true,
-            headers = {
-                ["Content-Type"] = "application/json",
-                ["X-Shared-Token"] = TOKEN,
-                ["Host"] = HOST,
-            }
-        }
-    )
-
-    if not res then
-        return nil, err or "falha na requisicao"
+    local origins = { INTERNAL_DSN }
+    if EXTERNAL_DSN ~= "" and EXTERNAL_DSN ~= INTERNAL_DSN then
+        table.insert(origins, EXTERNAL_DSN)
     end
 
-    if res.status < 200 or res.status >= 300 then
-        return nil, string.format("sync retornou status %s: %s", res.status, res.body or "")
+    local last_error = nil
+    for _, origin in ipairs(origins) do
+        local res, err = request_sync(origin, body)
+        if res then
+            if res.status >= 200 and res.status < 300 then
+                local decoded = cjson.decode(res.body or "{}")
+                return decoded or true, nil
+            end
+            return nil, string.format("sync retornou status %s: %s", res.status, res.body or "")
+        end
+        last_error = err or "falha na requisicao"
     end
 
-    local decoded = cjson.decode(res.body or "{}")
-    return decoded or true, nil
+    return nil, last_error or "nenhuma origem da API disponivel"
 end
 
 return M

--- a/tests/smoke/test_user_profile_contract.py
+++ b/tests/smoke/test_user_profile_contract.py
@@ -67,6 +67,28 @@ class UserProfileContractTests(unittest.TestCase):
         self.assertIn("user_profile_handler", content)
         self.assertNotIn('request_method ~= "GET"', access)
 
+    def test_profile_reads_do_not_call_the_python_api(self) -> None:
+        handler = (
+            ROOT / "studio/nginx/lua/admin_api/user_profile_handler.lua"
+        ).read_text(encoding="utf-8")
+        get_block = handler[
+            handler.index('if method == "GET" then'):
+            handler.index('if method == "PATCH" then')
+        ]
+
+        self.assertIn("store.get(email)", get_block)
+        self.assertNotIn("sync_profile", get_block)
+
+    def test_user_sync_prefers_direct_api_and_keeps_remote_fallback(self) -> None:
+        source = (
+            ROOT / "studio/nginx/lua/admin_api/user_sync.lua"
+        ).read_text(encoding="utf-8")
+
+        self.assertIn('os.getenv("PROJECTS_API_INTERNAL_URL")', source)
+        self.assertIn('INTERNAL_DSN = "http://projects-api:18000"', source)
+        self.assertIn("table.insert(origins, EXTERNAL_DSN)", source)
+        self.assertIn('"User-Agent"] = "studio-nginx-internal/1.0"', source)
+
     def test_flutter_loads_profile_and_exposes_editor(self) -> None:
         main = (
             ROOT / "studio/seletor_de_projetos/lib/main.dart"


### PR DESCRIPTION
## Problema

Depois da integração do perfil, `GET /api/user/me` passou a sincronizar a projeção com a API Python de forma síncrona em toda abertura do Studio.

Na instalação em uma máquina, esse sync usava `SERVER_DOMAIN`, saindo do container para `192.168.0.10:80`, passando pelo Traefik e voltando para `projects-api`, apesar dos serviços compartilharem a `rede-supabase`.

Quando essa chamada travava, o carregamento inicial mantinha uma requisição de sync pendente e as chamadas seguintes para `/api/projects` terminavam em `504 Gateway Timeout`.

## Correção

- remove a sincronização da projeção no `GET /api/user/me`;
- mantém o GET restrito à leitura do perfil no YAML/cache;
- continua sincronizando em alterações reais de perfil e avatar;
- faz o sync tentar primeiro `http://projects-api:18000` pela rede Docker;
- mantém fallback para `SERVER_DOMAIN` quando o Studio roda em outra máquina;
- envia um User-Agent explícito para não cair no router de bloqueio de agentes vazios do Traefik;
- remove keepalive da chamada curta de sincronização;
- adiciona smoke tests para impedir que o GET volte a depender da API Python.

## Efeito esperado

- abrir o Studio não depende mais da disponibilidade da projeção Python;
- o perfil aparece imediatamente pelo Authelia/OpenResty;
- `/api/projects` deixa de competir com um sync disparado pelo bootstrap do Flutter;
- edições continuam transacionais: se a projeção falhar, a escrita do perfil é revertida.

## Aplicação

Após o merge:

```bash
cd studio
docker compose up -d --build nginx
```

Como podem existir requisições antigas presas no processo atual, reinicie também a API uma vez:

```bash
docker restart projects-api
```

Depois valide:

```bash
docker exec nginx curl -sS --max-time 3 http://projects-api:18000/openapi.json >/dev/null && echo API_OK
```
