### PR TITLE
fix: carrega env do servidor no Traefik

### DIFF
--- a/LEIAME.md
+++ b/LEIAME.md
@@ -160,7 +160,7 @@ docker compose -f docker-compose-api.yml --env-file .env up --build -d
 Inicie o Traefik:
 
 ```bash
-docker compose -f traefik/docker-compose.yml up -d
+docker compose -f traefik/docker-compose.yml --env-file .env up -d
 ```
 
 Inicie os projetos existentes:

--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ docker compose -f docker-compose-api.yml --env-file .env up --build -d
 Start Traefik:
 
 ```bash
-docker compose -f traefik/docker-compose.yml up -d
+docker compose -f traefik/docker-compose.yml --env-file .env up -d
 ```
 
 Start existing projects:

--- a/start.sh
+++ b/start.sh
@@ -38,7 +38,7 @@ echo -e "\n✅ Supavisor está pronto."
 
 echo "▶️  Iniciando o Traefik..."
 
-docker compose -f traefik/docker-compose.yml up -d
+docker compose -f traefik/docker-compose.yml --env-file .env up -d
 echo "✅ Traefik iniciado."
 
 echo "▶️  Iniciando projetos Supabase..."

--- a/stop_containers.sh
+++ b/stop_containers.sh
@@ -32,7 +32,7 @@ done
 echo "✅ Todos os projetos parados."
 
 echo "⏹️  Parando o Traefik..."
-docker compose -f traefik/docker-compose.yml down
+docker compose -f traefik/docker-compose.yml --env-file .env down
 echo "✅ Traefik parado."
 
 echo "⏹️  Parando a base de dados e serviços Supabase..."

--- a/tests/smoke/test_traefik_env_contract.py
+++ b/tests/smoke/test_traefik_env_contract.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+import pathlib
+import re
+import unittest
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+
+
+class TraefikEnvContractTests(unittest.TestCase):
+    def test_server_example_contains_every_traefik_compose_variable(self) -> None:
+        compose = (
+            ROOT / "servidor/traefik/docker-compose.yml"
+        ).read_text(encoding="utf-8")
+        example = (ROOT / "servidor/.env.example").read_text(encoding="utf-8")
+
+        compose_variables = set(re.findall(r"\$\{([A-Z][A-Z0-9_]*)\}", compose))
+        example_variables = {
+            line.split("=", 1)[0]
+            for line in example.splitlines()
+            if line and not line.startswith("#") and "=" in line
+        }
+
+        self.assertEqual(set(), compose_variables - example_variables)
+
+    def test_start_and_stop_load_server_env_for_traefik(self) -> None:
+        expected = "docker compose -f traefik/docker-compose.yml --env-file .env"
+        for script_name in ("start.sh", "stop_containers.sh"):
+            source = (ROOT / script_name).read_text(encoding="utf-8")
+            self.assertIn(expected, source)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Problema

`start.sh`, `stop_containers.sh` e os comandos manuais chamavam `servidor/traefik/docker-compose.yml` sem `--env-file .env`.

Como o Compose do Traefik fica em uma subpasta, as variáveis declaradas em `servidor/.env` não eram carregadas de forma explícita. Isso deixava `TRAEFIK_IMAGE`, portas, `TZ` e as configurações do deny-service vazias, fazendo até o `docker compose down` falhar na validação.

## Correção

- `start.sh` passa `--env-file .env` ao iniciar o Traefik;
- `stop_containers.sh` passa `--env-file .env` ao parar o Traefik;
- README e LEIAME usam o mesmo comando no fluxo manual;
- teste de contrato compara todas as variáveis `${...}` do Compose do Traefik com `servidor/.env.example`;
- teste garante que start e stop sempre carreguem o env do servidor.

## Observação

As variáveis já existem em `servidor/.env.example`. A regressão era o Compose não carregar o arquivo gerado em `servidor/.env` ao operar o Compose localizado em `servidor/traefik/`.