### PR TITLE
fix(studio): restaura abertura de projeto sem 502

### DIFF
--- a/studio/docker-compose.yml
+++ b/studio/docker-compose.yml
@@ -29,6 +29,9 @@ services:
     ports:
       - "${STUDIO_HTTPS_PORT}:443"
     restart: unless-stopped
+    depends_on:
+      studio:
+        condition: service_started
     networks: [default, rede-supabase]
     env_file:
       - .env

--- a/studio/docker-compose.yml
+++ b/studio/docker-compose.yml
@@ -42,10 +42,22 @@ services:
     container_name: supabase-studio
     image: ${STUDIO_IMAGE}
     restart: unless-stopped
+    healthcheck:
+      test:
+        [
+          "CMD-SHELL",
+          "node -e \"fetch('http://localhost:3000/api/platform/profile').then((r) => {if (r.status !== 200) throw new Error(r.status)})\""
+        ]
+      timeout: 10s
+      interval: 5s
+      retries: 3
+      start_period: 20s
     env_file:
       - .analytics.env
     networks: [default, rede-supabase]
     environment:
+      # O servidor standalone do Studio precisa escutar também na interface Docker.
+      HOSTNAME: "0.0.0.0"
       STUDIO_PG_META_URL: https://nginx:443/api/platform/pg-meta
       DEFAULT_ORGANIZATION_NAME: ${DEFAULT_ORGANIZATION_NAME}
       DEFAULT_PROJECT_NAME: postgres

--- a/tests/smoke/test_studio_runtime_contract.py
+++ b/tests/smoke/test_studio_runtime_contract.py
@@ -11,7 +11,7 @@ class StudioRuntimeContractTests(unittest.TestCase):
     def setUpClass(cls) -> None:
         compose = (ROOT / "studio/docker-compose.yml").read_text(encoding="utf-8")
         nginx_start = compose.index("  nginx:\n")
-        studio_start = compose.index("  studio:\n", nginx_start)
+        studio_start = compose.index("\n  studio:\n", nginx_start) + 1
         cls.nginx = compose[nginx_start:studio_start]
         studio_end = compose.index("  # postgres:", studio_start)
         cls.studio = compose[studio_start:studio_end]

--- a/tests/smoke/test_studio_runtime_contract.py
+++ b/tests/smoke/test_studio_runtime_contract.py
@@ -10,9 +10,11 @@ class StudioRuntimeContractTests(unittest.TestCase):
     @classmethod
     def setUpClass(cls) -> None:
         compose = (ROOT / "studio/docker-compose.yml").read_text(encoding="utf-8")
-        start = compose.index("  studio:\n")
-        end = compose.index("  # postgres:", start)
-        cls.studio = compose[start:end]
+        nginx_start = compose.index("  nginx:\n")
+        studio_start = compose.index("  studio:\n", nginx_start)
+        cls.nginx = compose[nginx_start:studio_start]
+        studio_end = compose.index("  # postgres:", studio_start)
+        cls.studio = compose[studio_start:studio_end]
 
     def test_studio_listens_on_the_docker_interface(self) -> None:
         self.assertIn('HOSTNAME: "0.0.0.0"', self.studio)
@@ -21,6 +23,11 @@ class StudioRuntimeContractTests(unittest.TestCase):
         self.assertIn("http://localhost:3000/api/platform/profile", self.studio)
         self.assertIn("start_period: 20s", self.studio)
         self.assertIn("timeout: 10s", self.studio)
+
+    def test_gateway_starts_after_the_studio_container_exists(self) -> None:
+        self.assertIn("depends_on:", self.nginx)
+        self.assertIn("studio:", self.nginx)
+        self.assertIn("condition: service_started", self.nginx)
 
 
 if __name__ == "__main__":

--- a/tests/smoke/test_studio_runtime_contract.py
+++ b/tests/smoke/test_studio_runtime_contract.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+import pathlib
+import unittest
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+
+
+class StudioRuntimeContractTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        compose = (ROOT / "studio/docker-compose.yml").read_text(encoding="utf-8")
+        start = compose.index("  studio:\n")
+        end = compose.index("  # postgres:", start)
+        cls.studio = compose[start:end]
+
+    def test_studio_listens_on_the_docker_interface(self) -> None:
+        self.assertIn('HOSTNAME: "0.0.0.0"', self.studio)
+
+    def test_studio_healthcheck_matches_the_dashboard_listener(self) -> None:
+        self.assertIn("http://localhost:3000/api/platform/profile", self.studio)
+        self.assertIn("start_period: 20s", self.studio)
+        self.assertIn("timeout: 10s", self.studio)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Diagnóstico

O `set-project` não era o ponto que estava falhando:

- o endpoint concluía e gravava corretamente o cookie `supabase_project`;
- a falha acontecia na requisição seguinte para `/project/default`;
- essa rota já passou pelo contexto Lua e então faz proxy para `studio:3000`;
- a página `502 Bad Gateway` é gerada pelo OpenResty;
- ao mesmo tempo, o container `supabase-studio` aparecia como `unhealthy`.

O Studio standalone usa `HOSTNAME` para escolher a interface de escuta. O Compose do projeto não fixava esse valor, embora o Compose oficial da mesma geração do Studio use `HOSTNAME: "0.0.0.0"`. Isso pode deixar o processo preso ao hostname interno do container, enquanto o healthcheck consulta `localhost:3000` e o Nginx tenta acessar a interface Docker.

Também não havia ordenação entre os containers. Em uma recriação, o Nginx podia iniciar e resolver o upstream enquanto o container do Studio ainda estava sendo substituído.

`set_project.lua`, a assinatura do cookie e `project_ref.lua` não foram alterados por esta correção.

## Correção

- fixa `HOSTNAME: "0.0.0.0"` no serviço `studio`;
- declara explicitamente o healthcheck de `/api/platform/profile` com `start_period` de 20 segundos;
- inicia o container do Nginx somente depois que o container do Studio já existe;
- adiciona teste de contrato para impedir a remoção acidental dessas garantias.

## Validação

- `python -m unittest tests/smoke/test_studio_runtime_contract.py -v`;
- parse do `studio/docker-compose.yml` com YAML;
- branch baseada na `main` em `24af1f2c`.

## Aplicação

Após o merge:

```bash
cd studio
docker compose up -d --build --force-recreate studio nginx
docker compose ps
```

O esperado é `supabase-studio` mudar para `healthy` e `/project/default` voltar a ser atendido pelo Studio depois da seleção do projeto.