### PR TITLE
fix(storage): inicializa body antes de reescrever Vector Buckets

### DIFF
--- a/studio/nginx/lua/proxy_rewrites/storage.lua
+++ b/studio/nginx/lua/proxy_rewrites/storage.lua
@@ -37,6 +37,10 @@ local function read_json_body()
 end
 
 local function set_json_body(body)
+    -- ngx.req.set_body_data exige que o corpo tenha sido inicializado antes,
+    -- inclusive quando a requisicao original era GET e nao tinha payload.
+    ngx.req.read_body()
+
     local encoded, err = cjson.encode(body)
     if not encoded then
         return nil, err

--- a/tests/smoke/test_storage_platform_router.py
+++ b/tests/smoke/test_storage_platform_router.py
@@ -30,6 +30,18 @@ class StoragePlatformRouterTests(unittest.TestCase):
         self.assertIn('ngx.req.set_method(ngx.HTTP_POST)', rewrite)
         self.assertIn('set_json_body({})', rewrite)
 
+    def test_json_body_is_initialized_before_replacing_a_get_body(self) -> None:
+        rewrite = REWRITE.read_text(encoding="utf-8")
+        function_start = rewrite.index("local function set_json_body")
+        function_end = rewrite.index("\nend\n", function_start)
+        set_json_body = rewrite[function_start:function_end]
+
+        self.assertIn("ngx.req.read_body()", set_json_body)
+        self.assertLess(
+            set_json_body.index("ngx.req.read_body()"),
+            set_json_body.index("ngx.req.set_body_data(encoded)"),
+        )
+
     def test_create_renames_the_studio_bucket_field(self) -> None:
         rewrite = REWRITE.read_text(encoding="utf-8")
 

--- a/tests/smoke/test_storage_platform_router.py
+++ b/tests/smoke/test_storage_platform_router.py
@@ -33,7 +33,7 @@ class StoragePlatformRouterTests(unittest.TestCase):
     def test_json_body_is_initialized_before_replacing_a_get_body(self) -> None:
         rewrite = REWRITE.read_text(encoding="utf-8")
         function_start = rewrite.index("local function set_json_body")
-        function_end = rewrite.index("\nend\n", function_start)
+        function_end = rewrite.index("local original_uri", function_start)
         set_json_body = rewrite[function_start:function_end]
 
         self.assertIn("ngx.req.read_body()", set_json_body)


### PR DESCRIPTION
## Diagnóstico

O backend vetorial está funcionando corretamente. O script consultou diretamente o Storage API e recebeu:

```text
HTTP 200 {"vectorBuckets":[]}
```

O `500` ocorre antes do proxy, dentro do OpenResty:

```text
storage.lua:46: request body not read yet
[C]: in function 'set_body_data'
```

A chamada original do Studio é um `GET`, portanto não chega com corpo inicializado. O router converte essa operação para `POST /vector/ListVectorBuckets` e precisa inserir `{}` como payload. Porém `ngx.req.set_body_data()` só pode ser chamado depois de `ngx.req.read_body()`, inclusive quando a requisição original não possuía corpo.

Os avisos `rewrite ... does not match` não causam o erro; são somente logs das regras antigas que não corresponderam à rota `vector-buckets`.

## Correção

- chama `ngx.req.read_body()` dentro de `set_json_body()` antes de `ngx.req.set_body_data()`;
- mantém o encaminhamento para o Storage API real;
- não cria fallback, resposta vazia ou tratamento que esconda falhas do backend;
- adiciona teste de regressão garantindo a ordem `read_body -> set_body_data`.

## Fluxo corrigido

```text
GET /api/platform/storage/default/vector-buckets
  -> ngx.req.read_body()
  -> corpo JSON {}
  -> método POST
  -> /storage/v1/vector/ListVectorBuckets
  -> Storage API/pgvector
  -> {"vectorBuckets":[]}
```

## Aplicação

Após o merge:

```bash
cd /home/gustavo/supabase-multitenant-2
git pull origin main
cd studio
docker compose up -d --build --force-recreate nginx
```

Não é necessário executar novamente `enable_vector_storage.sh`; o `meu_projeto` já está configurado e a consulta direta ao Storage API passou.