### PR TITLE
fix(storage): mapeia detalhes e índices de Vector Buckets

### DIFF
--- a/studio/nginx/lua/proxy_rewrites/storage.lua
+++ b/studio/nginx/lua/proxy_rewrites/storage.lua
@@ -1,7 +1,12 @@
 local cjson = require("cjson.safe")
+local cjson_raw = require("cjson")
 local platform_router = require("proxy_rewrites.storage_platform_router")
 
 local storage_prefix = "/storage/v1"
+
+local function json_array(items)
+    return setmetatable(items or {}, cjson_raw.array_mt)
+end
 
 local function reject(problem)
     local status = problem.status or ngx.HTTP_BAD_REQUEST
@@ -107,6 +112,7 @@ local function set_route_body(route)
         if type(metadata_keys) ~= "table" then
             metadata_keys = {}
         end
+        metadata_keys = json_array(metadata_keys)
 
         return set_json_body({
             vectorBucketName = route.vector_bucket_name,

--- a/studio/nginx/lua/proxy_rewrites/storage.lua
+++ b/studio/nginx/lua/proxy_rewrites/storage.lua
@@ -51,46 +51,90 @@ local function set_json_body(body)
     return true
 end
 
-local original_uri = ngx.var.uri or ""
-local route, route_error = platform_router.resolve(original_uri, ngx.req.get_method())
+local function set_route_body(route)
+    if route.body_mode == nil then
+        return true
+    end
 
-if route then
     if route.body_mode == "empty_json_object" then
-        local ok, err = set_json_body({})
-        if not ok then
-            return reject({
-                status = ngx.HTTP_INTERNAL_SERVER_ERROR,
-                code = "storage_platform_body_encode_failed",
-                message = "Falha ao preparar requisicao do Storage: " .. tostring(err),
-            })
-        end
-    elseif route.body_mode == "vector_bucket_create" then
+        return set_json_body({})
+    end
+
+    if route.body_mode == "vector_bucket_identity" then
+        return set_json_body({
+            vectorBucketName = route.vector_bucket_name,
+        })
+    end
+
+    if route.body_mode == "vector_indexes_list" then
+        return set_json_body({
+            vectorBucketName = route.vector_bucket_name,
+            maxResults = 100,
+        })
+    end
+
+    if route.body_mode == "vector_index_identity" then
+        return set_json_body({
+            vectorBucketName = route.vector_bucket_name,
+            indexName = route.index_name,
+        })
+    end
+
+    if route.body_mode == "vector_bucket_create" then
         local body, err = read_json_body()
         if not body then
-            return reject({
-                status = ngx.HTTP_BAD_REQUEST,
-                code = "storage_platform_invalid_json",
-                message = "Corpo JSON invalido: " .. tostring(err),
-            })
+            return nil, "Corpo JSON invalido: " .. tostring(err), ngx.HTTP_BAD_REQUEST,
+                "storage_platform_invalid_json"
         end
 
         local vector_bucket_name = body.vectorBucketName or body.bucketName
         if type(vector_bucket_name) ~= "string" or vector_bucket_name == "" then
-            return reject({
-                status = ngx.HTTP_BAD_REQUEST,
-                code = "storage_platform_bucket_name_missing",
-                message = "bucketName e obrigatorio para criar um vector bucket",
-            })
+            return nil, "bucketName e obrigatorio para criar um vector bucket",
+                ngx.HTTP_BAD_REQUEST, "storage_platform_bucket_name_missing"
         end
 
-        local ok, encode_err = set_json_body({ vectorBucketName = vector_bucket_name })
-        if not ok then
-            return reject({
-                status = ngx.HTTP_INTERNAL_SERVER_ERROR,
-                code = "storage_platform_body_encode_failed",
-                message = "Falha ao preparar requisicao do Storage: " .. tostring(encode_err),
-            })
+        return set_json_body({ vectorBucketName = vector_bucket_name })
+    end
+
+    if route.body_mode == "vector_index_create" then
+        local body, err = read_json_body()
+        if not body then
+            return nil, "Corpo JSON invalido: " .. tostring(err), ngx.HTTP_BAD_REQUEST,
+                "storage_platform_invalid_json"
         end
+
+        local metadata_keys = body.metadataKeys
+        if type(metadata_keys) ~= "table" then
+            metadata_keys = {}
+        end
+
+        return set_json_body({
+            vectorBucketName = route.vector_bucket_name,
+            indexName = body.indexName,
+            dataType = body.dataType,
+            dimension = body.dimension,
+            distanceMetric = body.distanceMetric,
+            metadataConfiguration = {
+                nonFilterableMetadataKeys = metadata_keys,
+            },
+        })
+    end
+
+    return nil, "Modo de corpo do Storage nao reconhecido: " .. tostring(route.body_mode),
+        ngx.HTTP_INTERNAL_SERVER_ERROR, "storage_platform_body_mode_unknown"
+end
+
+local original_uri = ngx.var.uri or ""
+local route, route_error = platform_router.resolve(original_uri, ngx.req.get_method())
+
+if route then
+    local ok, err, status, code = set_route_body(route)
+    if not ok then
+        return reject({
+            status = status or ngx.HTTP_INTERNAL_SERVER_ERROR,
+            code = code or "storage_platform_body_encode_failed",
+            message = err or "Falha ao preparar requisicao do Storage",
+        })
     end
 
     if route.method == "POST" then
@@ -102,6 +146,10 @@ if route then
     end
 
     ngx.ctx.storage_platform_route = route.route_name
+    ngx.ctx.storage_platform_response_mode = route.response_mode
+    ngx.ctx.storage_platform_vector_bucket_name = route.vector_bucket_name
+    ngx.ctx.storage_platform_index_name = route.index_name
+    ngx.ctx.storage_platform_original_uri = original_uri
     ngx.req.set_uri(route.uri, false)
 elseif route_error then
     return reject(route_error)

--- a/studio/nginx/lua/proxy_rewrites/storage.lua
+++ b/studio/nginx/lua/proxy_rewrites/storage.lua
@@ -169,10 +169,13 @@ local body_data = ngx.req.get_body_data()
 if body_data then
     local body, decode_err = cjson.decode(body_data)
     if body and type(body) == "table" then
+        local body_changed = false
+
         if ngx.var.request_method == "POST" and path == "/bucket" then
             if body.id then
                 body.name = body.id
                 body.id = nil
+                body_changed = true
             end
         end
 
@@ -180,6 +183,7 @@ if body_data then
             if body.path then
                 body.prefix = body.path
                 body.path = nil
+                body_changed = true
             end
         end
 
@@ -187,6 +191,7 @@ if body_data then
             if body.paths then
                 body.prefixes = body.paths
                 body.paths = nil
+                body_changed = true
             end
         end
 
@@ -195,6 +200,7 @@ if body_data then
                 local clean_path = ngx.re.gsub(body.path, "^/", "", "jo")
                 body.paths = { clean_path }
                 body.path = nil
+                body_changed = true
             end
         end
 
@@ -216,6 +222,7 @@ if body_data then
                         destinationBucket = bucket_id,
                         destinationKey = body.to,
                     }
+                    body_changed = true
                     ngx.req.set_uri("/storage/v1/object/move", false)
                 else
                     ngx.log(ngx.ERR, "Nao foi possivel extrair bucketId da URL: ", ngx.var.request_uri)
@@ -223,11 +230,13 @@ if body_data then
             end
         end
 
-        local encoded, encode_err = cjson.encode(body)
-        if encoded then
-            ngx.req.set_body_data(encoded)
-        else
-            ngx.log(ngx.ERR, "Falha ao codificar o corpo da requisicao do Storage: ", encode_err)
+        if body_changed then
+            local encoded, encode_err = cjson.encode(body)
+            if encoded then
+                ngx.req.set_body_data(encoded)
+            else
+                ngx.log(ngx.ERR, "Falha ao codificar o corpo da requisicao do Storage: ", encode_err)
+            end
         end
     elseif decode_err then
         ngx.log(ngx.DEBUG, "Corpo do Storage nao e JSON; mantendo payload original: ", decode_err)

--- a/studio/nginx/lua/proxy_rewrites/storage_body_filter.lua
+++ b/studio/nginx/lua/proxy_rewrites/storage_body_filter.lua
@@ -1,14 +1,68 @@
-if ngx.ctx.process_sign_response and not ngx.ctx.sign_response_processed then
-    local cjson = require("cjson")
+local cjson = require("cjson")
+
+local function process_platform_response()
+    local mode = ngx.ctx.storage_platform_response_mode
+    if not mode or ngx.ctx.storage_platform_response_processed then
+        return false
+    end
+
     local chunk = ngx.arg[1]
     local eof = ngx.arg[2]
-    
+    ngx.ctx.storage_platform_response_body =
+        (ngx.ctx.storage_platform_response_body or "") .. (chunk or "")
+
+    if not eof then
+        ngx.arg[1] = nil
+        return true
+    end
+
+    ngx.ctx.storage_platform_response_processed = true
+    local raw_body = ngx.ctx.storage_platform_response_body or ""
+
+    -- Erros do Storage API devem atravessar sem alteracao para nao esconder a
+    -- causa real de falhas de provider, migration, permissao ou validacao.
+    if ngx.status < 200 or ngx.status >= 300 then
+        ngx.arg[1] = raw_body
+        return true
+    end
+
+    local success, response_data = pcall(cjson.decode, raw_body)
+    if not success or type(response_data) ~= "table" then
+        ngx.log(ngx.ERR, "Resposta JSON invalida do Storage API em ", tostring(mode))
+        ngx.arg[1] = raw_body
+        return true
+    end
+
+    if mode == "unwrap_vector_bucket" then
+        if type(response_data.vectorBucket) ~= "table" then
+            ngx.log(ngx.ERR, "GetVectorBucket retornou resposta sem vectorBucket")
+            ngx.arg[1] = raw_body
+            return true
+        end
+
+        ngx.arg[1] = cjson.encode(response_data.vectorBucket)
+        return true
+    end
+
+    ngx.log(ngx.ERR, "Modo de resposta do Storage nao reconhecido: ", tostring(mode))
+    ngx.arg[1] = raw_body
+    return true
+end
+
+if process_platform_response() then
+    return
+end
+
+if ngx.ctx.process_sign_response and not ngx.ctx.sign_response_processed then
+    local chunk = ngx.arg[1]
+    local eof = ngx.arg[2]
+
     ngx.ctx.response_body = (ngx.ctx.response_body or "") .. (chunk or "")
-    
+
     if eof then
         ngx.ctx.sign_response_processed = true
         local success, response_data = pcall(cjson.decode, ngx.ctx.response_body)
-        
+
         if success and response_data and type(response_data) == "table" and #response_data > 0 then
             local first_item = response_data[1]
             if first_item and first_item.signedURL then
@@ -22,7 +76,7 @@ if ngx.ctx.process_sign_response and not ngx.ctx.sign_response_processed then
                 local full_url = public_origin .. "/storage/v1/" .. signed_url
                 cjson.encode_escape_forward_slash(false)
                 local result = { signedUrl = full_url }
-                
+
                 ngx.arg[1] = cjson.encode(result)
             else
                 ngx.arg[1] = ngx.ctx.response_body

--- a/studio/nginx/lua/proxy_rewrites/storage_header_filter.lua
+++ b/studio/nginx/lua/proxy_rewrites/storage_header_filter.lua
@@ -1,4 +1,9 @@
 local path = ngx.var.uri
+
+if ngx.ctx.storage_platform_response_mode then
+    ngx.header.content_length = nil
+end
+
 if ngx.var.request_method == "POST" and ngx.re.match(path, "/storage/v1/object/sign/") then
     ngx.ctx.process_sign_response = true
     ngx.header.content_length = nil

--- a/studio/nginx/lua/proxy_rewrites/storage_platform_router.lua
+++ b/studio/nginx/lua/proxy_rewrites/storage_platform_router.lua
@@ -6,6 +6,15 @@ local function target(uri, options)
     return options
 end
 
+local function method_not_allowed(resource, allow)
+    return nil, {
+        status = 405,
+        code = "storage_platform_method_not_allowed",
+        message = "Metodo nao suportado para " .. resource,
+        allow = allow,
+    }
+end
+
 local function platform_path(uri)
     if type(uri) ~= "string" then
         return nil
@@ -69,9 +78,8 @@ function _M.resolve(uri, method)
         return target("/storage/v1/object/" .. object_bucket)
     end
 
-    -- O Studio expõe GET/POST em /vector-buckets, enquanto o Storage API usa
-    -- operações POST no namespace /vector. A adaptação fica concentrada aqui,
-    -- sem adicionar mais um rewrite específico no nginx.conf.
+    -- O Studio usa endpoints REST de plataforma, mas o Storage API implementa
+    -- Vector Buckets como operacoes POST no namespace /vector.
     if path == "/vector-buckets" then
         if method == "GET" then
             return target("/storage/v1/vector/ListVectorBuckets", {
@@ -89,12 +97,71 @@ function _M.resolve(uri, method)
             })
         end
 
-        return nil, {
-            status = 405,
-            code = "storage_platform_method_not_allowed",
-            message = "Metodo nao suportado para vector-buckets",
-            allow = "GET, POST",
-        }
+        return method_not_allowed("vector-buckets", "GET, POST")
+    end
+
+    local vector_bucket_name, index_name = path:match(
+        "^/vector-buckets/([^/]+)/indexes/([^/]+)$"
+    )
+    if vector_bucket_name and index_name then
+        if method == "DELETE" then
+            return target("/storage/v1/vector/DeleteIndex", {
+                method = "POST",
+                body_mode = "vector_index_identity",
+                route_name = "vector_index_delete",
+                vector_bucket_name = vector_bucket_name,
+                index_name = index_name,
+            })
+        end
+
+        return method_not_allowed("vector bucket index", "DELETE")
+    end
+
+    vector_bucket_name = path:match("^/vector-buckets/([^/]+)/indexes$")
+    if vector_bucket_name then
+        if method == "GET" then
+            return target("/storage/v1/vector/ListIndexes", {
+                method = "POST",
+                body_mode = "vector_indexes_list",
+                route_name = "vector_indexes_list",
+                vector_bucket_name = vector_bucket_name,
+            })
+        end
+
+        if method == "POST" then
+            return target("/storage/v1/vector/CreateIndex", {
+                method = "POST",
+                body_mode = "vector_index_create",
+                route_name = "vector_index_create",
+                vector_bucket_name = vector_bucket_name,
+            })
+        end
+
+        return method_not_allowed("vector bucket indexes", "GET, POST")
+    end
+
+    vector_bucket_name = path:match("^/vector-buckets/([^/]+)$")
+    if vector_bucket_name then
+        if method == "GET" then
+            return target("/storage/v1/vector/GetVectorBucket", {
+                method = "POST",
+                body_mode = "vector_bucket_identity",
+                response_mode = "unwrap_vector_bucket",
+                route_name = "vector_bucket_get",
+                vector_bucket_name = vector_bucket_name,
+            })
+        end
+
+        if method == "DELETE" then
+            return target("/storage/v1/vector/DeleteVectorBucket", {
+                method = "POST",
+                body_mode = "vector_bucket_identity",
+                route_name = "vector_bucket_delete",
+                vector_bucket_name = vector_bucket_name,
+            })
+        end
+
+        return method_not_allowed("vector bucket", "GET, DELETE")
     end
 
     return nil, {

--- a/studio/nginx/lua/proxy_rewrites/storage_vector_platform.lua
+++ b/studio/nginx/lua/proxy_rewrites/storage_vector_platform.lua
@@ -1,0 +1,213 @@
+local cjson = require("cjson")
+local cjson_safe = require("cjson.safe")
+local http = require("resty.http")
+
+local _M = {}
+
+local function json_array(items)
+    return setmetatable(items or {}, cjson.array_mt)
+end
+
+local function respond_json(status, payload)
+    ngx.status = status
+    ngx.header["Content-Type"] = "application/json; charset=utf-8"
+    ngx.say(cjson.encode(payload))
+    return ngx.exit(status)
+end
+
+local function respond_upstream(res)
+    ngx.status = res.status
+    ngx.header["Content-Type"] = res.headers["Content-Type"]
+        or res.headers["content-type"]
+        or "application/json; charset=utf-8"
+
+    if res.body and res.body ~= "" then
+        ngx.print(res.body)
+    end
+
+    return ngx.exit(res.status)
+end
+
+local function storage_request(path, payload)
+    local base_url = (ngx.var.server_path or ""):gsub("/+$", "")
+    if base_url == "" then
+        return nil, "server_path ausente"
+    end
+
+    local service_key = ngx.ctx.service_key
+    if not service_key or service_key == "" then
+        return nil, "service key ausente"
+    end
+
+    local encoded, encode_err = cjson_safe.encode(payload)
+    if not encoded then
+        return nil, "falha ao serializar payload: " .. tostring(encode_err)
+    end
+
+    local httpc = http.new()
+    httpc:set_timeout(10000)
+
+    return httpc:request_uri(base_url .. path, {
+        method = "POST",
+        body = encoded,
+        ssl_verify = false,
+        keepalive = false,
+        headers = {
+            ["Accept"] = "application/json",
+            ["Authorization"] = "Bearer " .. service_key,
+            ["apikey"] = service_key,
+            ["Content-Type"] = "application/json",
+            ["User-Agent"] = "studio-storage-compat/1.0",
+        },
+    })
+end
+
+local function decode_upstream_json(res, operation)
+    local payload, decode_err = cjson_safe.decode(res.body or "")
+    if type(payload) ~= "table" then
+        return nil, string.format(
+            "%s retornou JSON invalido: %s",
+            operation,
+            tostring(decode_err or "payload nao e objeto")
+        )
+    end
+
+    return payload
+end
+
+local function fetch_full_index(vector_bucket_name, index_name)
+    local res, request_err = storage_request("/storage/v1/vector/GetIndex", {
+        vectorBucketName = vector_bucket_name,
+        indexName = index_name,
+    })
+
+    if not res then
+        return nil, {
+            status = ngx.HTTP_BAD_GATEWAY,
+            message = "Falha ao consultar GetIndex: " .. tostring(request_err),
+        }
+    end
+
+    if res.status < 200 or res.status >= 300 then
+        return nil, {
+            upstream = res,
+        }
+    end
+
+    local payload, decode_err = decode_upstream_json(res, "GetIndex")
+    if not payload then
+        return nil, {
+            status = ngx.HTTP_BAD_GATEWAY,
+            message = decode_err,
+        }
+    end
+
+    if type(payload.index) ~= "table" then
+        return nil, {
+            status = ngx.HTTP_BAD_GATEWAY,
+            message = "GetIndex retornou resposta sem index",
+        }
+    end
+
+    return payload.index
+end
+
+local function handle_list_indexes()
+    local vector_bucket_name = ngx.ctx.storage_platform_vector_bucket_name
+    if not vector_bucket_name or vector_bucket_name == "" then
+        return respond_json(ngx.HTTP_BAD_GATEWAY, {
+            error = "storage_platform_vector_bucket_missing",
+            message = "Nome do vector bucket nao foi preservado pelo router",
+        })
+    end
+
+    local list_res, request_err = storage_request("/storage/v1/vector/ListIndexes", {
+        vectorBucketName = vector_bucket_name,
+        maxResults = 100,
+    })
+
+    if not list_res then
+        return respond_json(ngx.HTTP_BAD_GATEWAY, {
+            error = "storage_platform_upstream_unavailable",
+            message = "Falha ao consultar ListIndexes: " .. tostring(request_err),
+        })
+    end
+
+    if list_res.status < 200 or list_res.status >= 300 then
+        return respond_upstream(list_res)
+    end
+
+    local list_payload, decode_err = decode_upstream_json(list_res, "ListIndexes")
+    if not list_payload then
+        return respond_json(ngx.HTTP_BAD_GATEWAY, {
+            error = "storage_platform_invalid_upstream_json",
+            message = decode_err,
+        })
+    end
+
+    if type(list_payload.indexes) ~= "table" then
+        return respond_json(ngx.HTTP_BAD_GATEWAY, {
+            error = "storage_platform_invalid_upstream_shape",
+            message = "ListIndexes retornou resposta sem indexes",
+        })
+    end
+
+    local threads = {}
+    for position, summary in ipairs(list_payload.indexes) do
+        local index_name = type(summary) == "table" and summary.indexName or nil
+        if type(index_name) ~= "string" or index_name == "" then
+            return respond_json(ngx.HTTP_BAD_GATEWAY, {
+                error = "storage_platform_invalid_upstream_shape",
+                message = "ListIndexes retornou item sem indexName",
+            })
+        end
+
+        threads[position] = ngx.thread.spawn(function()
+            return fetch_full_index(vector_bucket_name, index_name)
+        end)
+    end
+
+    local indexes = json_array({})
+    for position, thread in ipairs(threads) do
+        local thread_ok, index, index_err = ngx.thread.wait(thread)
+        if not thread_ok then
+            return respond_json(ngx.HTTP_BAD_GATEWAY, {
+                error = "storage_platform_index_lookup_failed",
+                message = "GetIndex falhou: " .. tostring(index),
+            })
+        end
+
+        if not index then
+            if index_err and index_err.upstream then
+                return respond_upstream(index_err.upstream)
+            end
+
+            return respond_json((index_err and index_err.status) or ngx.HTTP_BAD_GATEWAY, {
+                error = "storage_platform_index_lookup_failed",
+                message = (index_err and index_err.message) or "GetIndex falhou",
+            })
+        end
+
+        indexes[position] = index
+    end
+
+    local response = {
+        indexes = indexes,
+    }
+    if list_payload.nextToken ~= nil and list_payload.nextToken ~= cjson.null then
+        response.nextToken = list_payload.nextToken
+    end
+
+    return respond_json(ngx.HTTP_OK, response)
+end
+
+function _M.handle()
+    if ngx.ctx.storage_platform_route ~= "vector_indexes_list" then
+        return false
+    end
+
+    handle_list_indexes()
+    return true
+end
+
+return _M

--- a/studio/nginx/lua/security/inject_service_key_storage.lua
+++ b/studio/nginx/lua/security/inject_service_key_storage.lua
@@ -4,6 +4,7 @@ local project_ref = ngx.var.project_ref
 if not project_ref or project_ref == "default" then
     return
 end
+
 local get_service_key = require("security.get_service_key")
 local key = get_service_key(project_ref)
 if key and key ~= "" then
@@ -11,3 +12,8 @@ if key and key ~= "" then
     ngx.req.set_header("apikey", key)
     ngx.ctx.service_key = key
 end
+
+-- Algumas rotas de plataforma precisam combinar mais de uma operacao real do
+-- Storage API. O Studio oficial, por exemplo, lista os indexes e depois chama
+-- GetIndex para obter dimension e distanceMetric de cada item.
+require("proxy_rewrites.storage_vector_platform").handle()

--- a/tests/smoke/test_storage_platform_router.py
+++ b/tests/smoke/test_storage_platform_router.py
@@ -8,6 +8,10 @@ import unittest
 ROOT = pathlib.Path(__file__).resolve().parents[2]
 ROUTER = ROOT / "studio/nginx/lua/proxy_rewrites/storage_platform_router.lua"
 REWRITE = ROOT / "studio/nginx/lua/proxy_rewrites/storage.lua"
+VECTOR_PLATFORM = ROOT / "studio/nginx/lua/proxy_rewrites/storage_vector_platform.lua"
+HEADER_FILTER = ROOT / "studio/nginx/lua/proxy_rewrites/storage_header_filter.lua"
+BODY_FILTER = ROOT / "studio/nginx/lua/proxy_rewrites/storage_body_filter.lua"
+KEY_INJECTOR = ROOT / "studio/nginx/lua/security/inject_service_key_storage.lua"
 NGINX = ROOT / "studio/nginx/nginx.conf"
 
 
@@ -28,12 +32,12 @@ class StoragePlatformRouterTests(unittest.TestCase):
         self.assertIn('method = "POST"', router)
         self.assertIn('body_mode = "empty_json_object"', router)
         self.assertIn('ngx.req.set_method(ngx.HTTP_POST)', rewrite)
-        self.assertIn('set_json_body({})', rewrite)
+        self.assertIn('return set_json_body({})', rewrite)
 
     def test_json_body_is_initialized_before_replacing_a_get_body(self) -> None:
         rewrite = REWRITE.read_text(encoding="utf-8")
         function_start = rewrite.index("local function set_json_body")
-        function_end = rewrite.index("local original_uri", function_start)
+        function_end = rewrite.index("local function set_route_body", function_start)
         set_json_body = rewrite[function_start:function_end]
 
         self.assertIn("ngx.req.read_body()", set_json_body)
@@ -47,6 +51,61 @@ class StoragePlatformRouterTests(unittest.TestCase):
 
         self.assertIn('body.vectorBucketName or body.bucketName', rewrite)
         self.assertIn('set_json_body({ vectorBucketName = vector_bucket_name })', rewrite)
+
+    def test_vector_bucket_detail_uses_get_vector_bucket_and_unwraps_response(self) -> None:
+        router = ROUTER.read_text(encoding="utf-8")
+        rewrite = REWRITE.read_text(encoding="utf-8")
+        header_filter = HEADER_FILTER.read_text(encoding="utf-8")
+        body_filter = BODY_FILTER.read_text(encoding="utf-8")
+
+        self.assertIn('/storage/v1/vector/GetVectorBucket', router)
+        self.assertIn('body_mode = "vector_bucket_identity"', router)
+        self.assertIn('response_mode = "unwrap_vector_bucket"', router)
+        self.assertIn('vectorBucketName = route.vector_bucket_name', rewrite)
+        self.assertIn('ngx.ctx.storage_platform_response_mode = route.response_mode', rewrite)
+        self.assertIn('ngx.header.content_length = nil', header_filter)
+        self.assertIn('cjson.encode(response_data.vectorBucket)', body_filter)
+
+    def test_vector_bucket_indexes_match_the_studio_contract(self) -> None:
+        router = ROUTER.read_text(encoding="utf-8")
+        rewrite = REWRITE.read_text(encoding="utf-8")
+        vector_platform = VECTOR_PLATFORM.read_text(encoding="utf-8")
+        key_injector = KEY_INJECTOR.read_text(encoding="utf-8")
+
+        self.assertIn('/storage/v1/vector/ListIndexes', router)
+        self.assertIn('/storage/v1/vector/CreateIndex', router)
+        self.assertIn('body_mode = "vector_indexes_list"', router)
+        self.assertIn('body_mode = "vector_index_create"', router)
+        self.assertIn('maxResults = 100', rewrite)
+        self.assertIn('/storage/v1/vector/GetIndex', vector_platform)
+        self.assertIn('payload.index', vector_platform)
+        self.assertIn('indexes = indexes', vector_platform)
+        self.assertIn('storage_vector_platform").handle()', key_injector)
+
+    def test_vector_index_create_matches_the_studio_payload(self) -> None:
+        rewrite = REWRITE.read_text(encoding="utf-8")
+
+        self.assertIn('vectorBucketName = route.vector_bucket_name', rewrite)
+        self.assertIn('indexName = body.indexName', rewrite)
+        self.assertIn('dataType = body.dataType', rewrite)
+        self.assertIn('dimension = body.dimension', rewrite)
+        self.assertIn('distanceMetric = body.distanceMetric', rewrite)
+        self.assertIn('nonFilterableMetadataKeys = metadata_keys', rewrite)
+
+    def test_delete_routes_use_real_storage_vector_operations(self) -> None:
+        router = ROUTER.read_text(encoding="utf-8")
+
+        self.assertIn('/storage/v1/vector/DeleteVectorBucket', router)
+        self.assertIn('/storage/v1/vector/DeleteIndex', router)
+        self.assertIn('body_mode = "vector_index_identity"', router)
+
+    def test_vector_index_list_has_no_success_fallback_for_upstream_errors(self) -> None:
+        vector_platform = VECTOR_PLATFORM.read_text(encoding="utf-8")
+
+        self.assertIn('if list_res.status < 200 or list_res.status >= 300 then', vector_platform)
+        self.assertIn('return respond_upstream(list_res)', vector_platform)
+        self.assertIn('if res.status < 200 or res.status >= 300 then', vector_platform)
+        self.assertNotIn('vectorBuckets = json_array({})', vector_platform)
 
     def test_existing_bucket_and_object_routes_are_described_by_the_router(self) -> None:
         router = ROUTER.read_text(encoding="utf-8")
@@ -68,7 +127,14 @@ class StoragePlatformRouterTests(unittest.TestCase):
         if compiler is None:
             self.skipTest("luac nao esta instalado")
 
-        for path in (ROUTER, REWRITE):
+        for path in (
+            ROUTER,
+            REWRITE,
+            VECTOR_PLATFORM,
+            HEADER_FILTER,
+            BODY_FILTER,
+            KEY_INJECTOR,
+        ):
             subprocess.run([compiler, "-p", str(path)], check=True)
 
 


### PR DESCRIPTION
## Problema

Depois que a listagem de Vector Buckets passou a funcionar, a tela de detalhes encontrou as próximas rotas ainda não mapeadas:

```text
GET /api/platform/storage/default/vector-buckets/<bucket>
GET /api/platform/storage/default/vector-buckets/<bucket>/indexes
```

O router Lua devolvia `storage_platform_route_unmapped` para a segunda rota.

## Contrato real do Studio e Storage API

Na versão do Studio usada pelo projeto:

- `GET /vector-buckets/<bucket>` chama `GetVectorBucket` e devolve somente o objeto interno `vectorBucket`;
- `GET /vector-buckets/<bucket>/indexes` chama primeiro `ListIndexes`;
- como `ListIndexes` devolve apenas resumos, o Studio chama `GetIndex` para cada item e monta a resposta final com `dimension`, `distanceMetric` e os demais metadados.

Portanto, apenas encaminhar `ListIndexes` não seria suficiente quando existirem tabelas vetoriais.

## Correção

O router centralizado agora cobre a família completa usada por essa tela:

```text
GET    /vector-buckets/<bucket>
DELETE /vector-buckets/<bucket>
GET    /vector-buckets/<bucket>/indexes
POST   /vector-buckets/<bucket>/indexes
DELETE /vector-buckets/<bucket>/indexes/<index>
```

Mapeamentos para o Storage API:

```text
GetVectorBucket
DeleteVectorBucket
ListIndexes
GetIndex
CreateIndex
DeleteIndex
```

### Resposta do bucket

O Storage API responde:

```json
{
  "vectorBucket": {
    "vectorBucketName": "rrrr",
    "creationTime": 1783900671
  }
}
```

O filtro devolve o contrato esperado pelo Studio:

```json
{
  "vectorBucketName": "rrrr",
  "creationTime": 1783900671
}
```

Erros do Storage API atravessam sem transformação.

### Listagem de índices

Foi adicionado `storage_vector_platform.lua`, executado somente depois da injeção real da `service_role`:

1. chama `ListIndexes` no Storage API;
2. chama `GetIndex` em paralelo para cada resumo retornado;
3. preserva a ordem dos itens;
4. devolve `{ "indexes": [...] }` e `nextToken` quando existir;
5. repassa erros reais do upstream, sem resposta de sucesso fabricada.

Quando o backend realmente responder uma lista vazia, o resultado será naturalmente:

```json
{"indexes":[]}
```

### Criação de índice

O payload do Studio é convertido para o contrato do Storage API:

- adiciona `vectorBucketName` obtido da URL;
- preserva `indexName`, `dataType`, `dimension` e `distanceMetric`;
- converte `metadataKeys` para `metadataConfiguration.nonFilterableMetadataKeys`;
- mantém uma lista vazia como JSON `[]`, e não `{}`.

Também foi evitada a recodificação desnecessária de corpos JSON que não receberam patches, preservando arrays e tipos produzidos pelo adaptador da rota.

## Sem fallback falso

Esta PR não cria respostas vazias para esconder falhas. Erros de provider, migration, autenticação, validação ou `GetIndex` continuam visíveis com o status e corpo reais quando disponíveis.

## Aplicação

Após o merge:

```bash
cd /home/gustavo/supabase-multitenant-2
git pull origin main
cd studio
docker compose up -d --build --force-recreate nginx
```

Não é necessário executar novamente `enable_vector_storage.sh`; o backend pgvector do projeto já está configurado.