### PR TITLE
fix(storage): escapa hífen nas rotas Lua de Vector Buckets

### DIFF
--- a/studio/nginx/lua/proxy_rewrites/storage_platform_router.lua
+++ b/studio/nginx/lua/proxy_rewrites/storage_platform_router.lua
@@ -100,8 +100,10 @@ function _M.resolve(uri, method)
         return method_not_allowed("vector-buckets", "GET, POST")
     end
 
+    -- '-' e um quantificador especial em patterns Lua. Ele precisa ser escapado
+    -- como '%-' quando a familia /vector-buckets e reconhecida por string.match.
     local vector_bucket_name, index_name = path:match(
-        "^/vector-buckets/([^/]+)/indexes/([^/]+)$"
+        "^/vector%-buckets/([^/]+)/indexes/([^/]+)$"
     )
     if vector_bucket_name and index_name then
         if method == "DELETE" then
@@ -117,7 +119,7 @@ function _M.resolve(uri, method)
         return method_not_allowed("vector bucket index", "DELETE")
     end
 
-    vector_bucket_name = path:match("^/vector-buckets/([^/]+)/indexes$")
+    vector_bucket_name = path:match("^/vector%-buckets/([^/]+)/indexes$")
     if vector_bucket_name then
         if method == "GET" then
             return target("/storage/v1/vector/ListIndexes", {
@@ -140,7 +142,7 @@ function _M.resolve(uri, method)
         return method_not_allowed("vector bucket indexes", "GET, POST")
     end
 
-    vector_bucket_name = path:match("^/vector-buckets/([^/]+)$")
+    vector_bucket_name = path:match("^/vector%-buckets/([^/]+)$")
     if vector_bucket_name then
         if method == "GET" then
             return target("/storage/v1/vector/GetVectorBucket", {

--- a/tests/smoke/test_storage_platform_router.py
+++ b/tests/smoke/test_storage_platform_router.py
@@ -66,6 +66,43 @@ class StoragePlatformRouterTests(unittest.TestCase):
         self.assertIn('ngx.header.content_length = nil', header_filter)
         self.assertIn('cjson.encode(response_data.vectorBucket)', body_filter)
 
+    def test_vector_bucket_patterns_escape_the_lua_hyphen_quantifier(self) -> None:
+        router = ROUTER.read_text(encoding="utf-8")
+
+        self.assertIn('^/vector%-buckets/([^/]+)$', router)
+        self.assertIn('^/vector%-buckets/([^/]+)/indexes$', router)
+        self.assertIn('^/vector%-buckets/([^/]+)/indexes/([^/]+)$', router)
+        self.assertNotIn('^/vector-buckets/([^/]+)$', router)
+        self.assertNotIn('^/vector-buckets/([^/]+)/indexes$', router)
+
+    def test_vector_bucket_patterns_resolve_at_runtime_when_lua_is_available(self) -> None:
+        runtime = shutil.which("lua5.1") or shutil.which("lua") or shutil.which("resty")
+        if runtime is None:
+            self.skipTest("runtime Lua nao esta instalado")
+
+        lua_root = (ROOT / "studio/nginx/lua").as_posix()
+        script = f'''
+package.path = "{lua_root}/?.lua;{lua_root}/?/init.lua;" .. package.path
+local router = require("proxy_rewrites.storage_platform_router")
+
+local detail, detail_err = router.resolve(
+    "/api/platform/storage/default/vector-buckets/rrrr",
+    "GET"
+)
+assert(detail, detail_err and detail_err.message or "detail route missing")
+assert(detail.route_name == "vector_bucket_get", detail.route_name)
+assert(detail.vector_bucket_name == "rrrr", detail.vector_bucket_name)
+
+local indexes, indexes_err = router.resolve(
+    "/api/platform/storage/default/vector-buckets/rrrr/indexes",
+    "GET"
+)
+assert(indexes, indexes_err and indexes_err.message or "indexes route missing")
+assert(indexes.route_name == "vector_indexes_list", indexes.route_name)
+assert(indexes.vector_bucket_name == "rrrr", indexes.vector_bucket_name)
+'''
+        subprocess.run([runtime, "-e", script], check=True)
+
     def test_vector_bucket_indexes_match_the_studio_contract(self) -> None:
         router = ROUTER.read_text(encoding="utf-8")
         rewrite = REWRITE.read_text(encoding="utf-8")


### PR DESCRIPTION
## Causa real

O código da PR anterior já estava dentro do container, mas o teste direto do módulo Lua ainda retornava `storage_platform_route_unmapped` para:

```text
/api/platform/storage/default/vector-buckets/rrrr
/api/platform/storage/default/vector-buckets/rrrr/indexes
```

A causa era o pattern Lua usado no router:

```lua
^/vector-buckets/([^/]+)$
```

Em patterns Lua, `-` não é literal: ele é um quantificador de repetição mínima. Por isso, `string.match` não reconhecia a string real `vector-buckets`, embora o código e os `route_name` estivessem presentes no arquivo.

A rota raiz `/vector-buckets` funcionava porque ela usa comparação direta (`path == "/vector-buckets"`), não `string.match`.

## Correção

Escapa o hífen como `%-` em todos os patterns da família:

```lua
^/vector%-buckets/([^/]+)$
^/vector%-buckets/([^/]+)/indexes$
^/vector%-buckets/([^/]+)/indexes/([^/]+)$
```

Isso restaura:

- `GET /vector-buckets/<bucket>`;
- `DELETE /vector-buckets/<bucket>`;
- `GET /vector-buckets/<bucket>/indexes`;
- `POST /vector-buckets/<bucket>/indexes`;
- `DELETE /vector-buckets/<bucket>/indexes/<index>`.

## Regressão

Os testes agora:

- verificam explicitamente que os patterns usam `vector%-buckets`;
- rejeitam as formas incorretas sem escape;
- quando um runtime Lua está disponível, carregam o módulo real e executam `router.resolve()` para as duas URLs que falharam em produção;
- confirmam `vector_bucket_get`, `vector_indexes_list` e o bucket `rrrr`.

## Aplicação

Após o merge:

```bash
cd /home/gustavo/supabase-multitenant-2
git pull --ff-only origin main
cd studio
docker compose build nginx
docker compose up -d --force-recreate nginx
```

Validação dentro do container:

```bash
docker exec nginx /usr/local/openresty/bin/resty -e '
package.path = "/usr/local/openresty/lualib/?.lua;/usr/local/openresty/lualib/?/init.lua;" .. package.path
local router = require("proxy_rewrites.storage_platform_router")
for _, uri in ipairs({
  "/api/platform/storage/default/vector-buckets/rrrr",
  "/api/platform/storage/default/vector-buckets/rrrr/indexes",
}) do
  local route, err = router.resolve(uri, "GET")
  print(uri, route and route.route_name or err.message)
end
'
```

Esperado:

```text
.../vector-buckets/rrrr              vector_bucket_get
.../vector-buckets/rrrr/indexes      vector_indexes_list
```