### PR TITLE
feat(storage): configura S3 Vectors Wrapper por projeto

### DIFF
--- a/servidor/generateProject/.envtemplate
+++ b/servidor/generateProject/.envtemplate
@@ -33,6 +33,11 @@ VECTOR_BUCKET_PROVIDER=pgvector
 VECTOR_DATABASE_URL=postgres://${STORAGE_DB_USER}:${POSTGRES_PASSWORD}@${POSTGRES_HOST}:${POSTGRES_PORT}/${POSTGRES_DATABASE}
 VECTOR_DATABASE_CREATE=false
 VECTOR_STORE_MIGRATIONS_ENABLED=true
+# Preenchidas automaticamente por enable_vector_storage.sh. Elas autenticam o
+# protocolo S3 Vectors usado pelo Wrappers FDW; nao sao as chaves JWT do projeto.
+S3_PROTOCOL_ENABLED=true
+S3_PROTOCOL_ACCESS_KEY_ID=
+S3_PROTOCOL_ACCESS_KEY_SECRET=
 IMGPROXY_URL=http://imgproxy:5001
 IMGPROXY_IMAGE=darthsim/imgproxy:v4.0.11
 IMGPROXY_BIND=:5001

--- a/servidor/generateProject/enable_vector_storage.sh
+++ b/servidor/generateProject/enable_vector_storage.sh
@@ -41,7 +41,18 @@ STORAGE_DB_USER="${STORAGE_DB_USER:-supabase_storage_admin}"
 
 command -v docker >/dev/null 2>&1 || fail "docker nao esta instalado"
 command -v python3 >/dev/null 2>&1 || fail "python3 nao esta instalado"
+command -v openssl >/dev/null 2>&1 || fail "openssl nao esta instalado"
 docker inspect supabase-db >/dev/null 2>&1 || fail "Container supabase-db nao encontrado"
+
+# Credenciais independentes das chaves JWT. O protocolo S3/S3 Vectors usa
+# assinatura AWS SigV4 e o Wrappers FDW precisa desse par para acessar /vector.
+S3_PROTOCOL_ACCESS_KEY_ID="${S3_PROTOCOL_ACCESS_KEY_ID:-$(openssl rand -hex 16)}"
+S3_PROTOCOL_ACCESS_KEY_SECRET="${S3_PROTOCOL_ACCESS_KEY_SECRET:-$(openssl rand -hex 32)}"
+
+[[ "$S3_PROTOCOL_ACCESS_KEY_ID" =~ ^[0-9a-fA-F]{32}$ ]] \
+  || fail "S3_PROTOCOL_ACCESS_KEY_ID deve conter 32 caracteres hexadecimais"
+[[ "$S3_PROTOCOL_ACCESS_KEY_SECRET" =~ ^[0-9a-fA-F]{64}$ ]] \
+  || fail "S3_PROTOCOL_ACCESS_KEY_SECRET deve conter 64 caracteres hexadecimais"
 
 # O Storage API executa as migrations de storage_vectors com o usuario restrito.
 # A instalacao da extensao exige o administrador do Postgres e ocorre antes de
@@ -79,7 +90,10 @@ PY
 # Usa referencias Compose em vez de copiar a senha global para o arquivo do
 # projeto. O comando padrao carrega ../../.env antes de .env, portanto essas
 # referencias sao resolvidas pelo proprio Docker Compose.
-python3 - "$PROJECT_ENV" <<'PY'
+python3 - \
+  "$PROJECT_ENV" \
+  "$S3_PROTOCOL_ACCESS_KEY_ID" \
+  "$S3_PROTOCOL_ACCESS_KEY_SECRET" <<'PY'
 from pathlib import Path
 import sys
 
@@ -90,6 +104,9 @@ updates = {
     "VECTOR_DATABASE_URL": "postgres://${STORAGE_DB_USER}:${POSTGRES_PASSWORD}@${POSTGRES_HOST}:${POSTGRES_PORT}/${POSTGRES_DATABASE}",
     "VECTOR_DATABASE_CREATE": "false",
     "VECTOR_STORE_MIGRATIONS_ENABLED": "true",
+    "S3_PROTOCOL_ENABLED": "true",
+    "S3_PROTOCOL_ACCESS_KEY_ID": sys.argv[2],
+    "S3_PROTOCOL_ACCESS_KEY_SECRET": sys.argv[3],
 }
 
 lines = path.read_text(encoding="utf-8").splitlines()
@@ -111,13 +128,15 @@ for key, value in updates.items():
 path.write_text("\n".join(lines) + "\n", encoding="utf-8")
 PY
 
+chmod 600 "$PROJECT_ENV"
+
 echo "▶ Validando configuracao Compose..."
 (
   cd "$PROJECT_DIR"
   docker compose -p "$PROJECT_ID" --env-file ../../.env --env-file .env config >/dev/null
 )
 
-echo "▶ Recriando o Storage API com backend pgvector..."
+echo "▶ Recriando o Storage API com backend pgvector e protocolo S3 Vectors..."
 (
   cd "$PROJECT_DIR"
   docker compose -p "$PROJECT_ID" --env-file ../../.env --env-file .env \
@@ -143,6 +162,17 @@ STATUS="$(docker inspect -f '{{if .State.Health}}{{.State.Health.Status}}{{else}
   docker logs --tail 200 "$STORAGE_CONTAINER" >&2 || true
   fail "Storage nao ficou healthy dentro do prazo"
 }
+
+# Garante que o env_file realmente chegou ao processo que valida assinaturas
+# SigV4. Os valores nao sao impressos.
+docker exec "$STORAGE_CONTAINER" node -e '
+const access = process.env.S3_PROTOCOL_ACCESS_KEY_ID || "";
+const secret = process.env.S3_PROTOCOL_ACCESS_KEY_SECRET || "";
+if (!/^[0-9a-fA-F]{32}$/.test(access) || !/^[0-9a-fA-F]{64}$/.test(secret)) {
+  console.error("Credenciais S3 Protocol ausentes ou invalidas no Storage API");
+  process.exit(2);
+}
+'
 
 # Consulta o endpoint real do Storage API. Nenhuma resposta vazia e fabricada
 # pelo gateway e aceita: falhas de provider, migration ou banco encerram o script.
@@ -177,3 +207,4 @@ fetch("http://127.0.0.1:5000/vector/ListVectorBuckets", {
 '
 
 echo "✅ Storage Vectors habilitado para $PROJECT_ID usando o banco $POSTGRES_DATABASE (pgvector $VECTOR_VERSION)."
+echo "✅ Credenciais SigV4 por projeto instaladas sem serem exibidas."

--- a/servidor/generateProject/setup_vector_bucket_wrapper.sh
+++ b/servidor/generateProject/setup_vector_bucket_wrapper.sh
@@ -1,0 +1,419 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SERVER_ROOT="$(dirname "$SCRIPT_DIR")"
+
+fail() {
+  echo "❌ $*" >&2
+  exit 1
+}
+
+PROJECT_ID="${1:-}"
+BUCKET_NAME="${2:-}"
+
+[[ -n "$PROJECT_ID" && -n "$BUCKET_NAME" ]] \
+  || fail "Uso: $0 <project_id> <vector_bucket_name>"
+[[ "$PROJECT_ID" =~ ^[a-z_][a-z0-9_]{2,39}$ ]] \
+  || fail "project_id invalido"
+[[ "$BUCKET_NAME" != *$'\n'* && "$BUCKET_NAME" != *$'\r'* && "$BUCKET_NAME" != */* ]] \
+  || fail "vector_bucket_name invalido"
+
+PROJECT_DIR="$SERVER_ROOT/projects/$PROJECT_ID"
+GLOBAL_ENV="$SERVER_ROOT/.env"
+PROJECT_ENV="$PROJECT_DIR/.env"
+STORAGE_CONTAINER="supabase-storage-$PROJECT_ID"
+POSTGRES_DATABASE="_supabase_$PROJECT_ID"
+
+[[ -d "$PROJECT_DIR" ]] || fail "Projeto nao encontrado: $PROJECT_DIR"
+[[ -f "$GLOBAL_ENV" ]] || fail "Arquivo ausente: $GLOBAL_ENV"
+[[ -f "$PROJECT_ENV" ]] || fail "Arquivo ausente: $PROJECT_ENV"
+
+command -v docker >/dev/null 2>&1 || fail "docker nao esta instalado"
+command -v python3 >/dev/null 2>&1 || fail "python3 nao esta instalado"
+
+# Garante o provider pgvector, as migrations oficiais e um par SigV4 exclusivo
+# do projeto antes de criar o FDW que consulta o endpoint vetorial.
+"$SCRIPT_DIR/enable_vector_storage.sh" "$PROJECT_ID"
+
+set -a
+# shellcheck disable=SC1090
+source "$GLOBAL_ENV"
+# shellcheck disable=SC1090
+source "$PROJECT_ENV"
+set +a
+
+POSTGRES_USER="${POSTGRES_USER:-supabase_admin}"
+STORAGE_REGION="${STORAGE_REGION:-us-east-1}"
+S3_PROTOCOL_ACCESS_KEY_ID="${S3_PROTOCOL_ACCESS_KEY_ID:-}"
+S3_PROTOCOL_ACCESS_KEY_SECRET="${S3_PROTOCOL_ACCESS_KEY_SECRET:-}"
+
+[[ "$S3_PROTOCOL_ACCESS_KEY_ID" =~ ^[0-9a-fA-F]{32}$ ]] \
+  || fail "S3_PROTOCOL_ACCESS_KEY_ID ausente ou invalido"
+[[ "$S3_PROTOCOL_ACCESS_KEY_SECRET" =~ ^[0-9a-fA-F]{64}$ ]] \
+  || fail "S3_PROTOCOL_ACCESS_KEY_SECRET ausente ou invalido"
+
+docker inspect supabase-db >/dev/null 2>&1 || fail "Container supabase-db nao encontrado"
+docker inspect "$STORAGE_CONTAINER" >/dev/null 2>&1 \
+  || fail "Container $STORAGE_CONTAINER nao encontrado"
+
+mapfile -t VECTOR_NAMES < <(python3 - "$BUCKET_NAME" <<'PY'
+import re
+import sys
+
+name = sys.argv[1]
+# Equivalente para os nomes aceitos pelo Storage ao lodash snakeCase usado pelo
+# Studio: separa camelCase, troca pontuacao por '_' e normaliza para minusculas.
+value = re.sub(r"([a-z0-9])([A-Z])", r"\1_\2", name)
+value = re.sub(r"[^A-Za-z0-9]+", "_", value).strip("_").lower()
+if not value:
+    raise SystemExit("o nome do bucket nao produz um identificador SQL valido")
+print(f"{value}_fdw")
+print(f"{value}_fdw_server")
+PY
+)
+
+WRAPPER_NAME="${VECTOR_NAMES[0]:-}"
+SERVER_NAME="${VECTOR_NAMES[1]:-}"
+[[ -n "$WRAPPER_NAME" && -n "$SERVER_NAME" ]] || fail "Falha ao gerar nomes do wrapper"
+[[ ${#WRAPPER_NAME} -le 63 && ${#SERVER_NAME} -le 63 ]] \
+  || fail "Nome do bucket gera identificador maior que o limite de 63 bytes do Postgres"
+
+ACCESS_SECRET_NAME="${WRAPPER_NAME}_vault_access_key_id"
+SECRET_SECRET_NAME="${WRAPPER_NAME}_vault_secret_access_key"
+VECTOR_ENDPOINT="http://${STORAGE_CONTAINER}:5000/vector"
+
+# Confirma que o bucket existe no backend real antes de alterar o catalogo do
+# Postgres. A chamada usa a service_role apenas dentro do container do Storage.
+echo "▶ Validando o vector bucket '$BUCKET_NAME' no Storage API..."
+docker exec \
+  -e VECTOR_BUCKET_NAME="$BUCKET_NAME" \
+  "$STORAGE_CONTAINER" \
+  node -e '
+const key = process.env.SERVICE_KEY;
+const bucket = process.env.VECTOR_BUCKET_NAME;
+if (!key || !bucket) process.exit(2);
+fetch("http://127.0.0.1:5000/vector/GetVectorBucket", {
+  method: "POST",
+  headers: {
+    "Content-Type": "application/json",
+    "Authorization": `Bearer ${key}`,
+    "apikey": key,
+  },
+  body: JSON.stringify({ vectorBucketName: bucket }),
+}).then(async (response) => {
+  const text = await response.text();
+  if (!response.ok) {
+    console.error(`GetVectorBucket HTTP ${response.status}: ${text}`);
+    process.exit(3);
+  }
+  const payload = JSON.parse(text);
+  if (payload?.vectorBucket?.vectorBucketName !== bucket) {
+    console.error("GetVectorBucket retornou um bucket inesperado");
+    process.exit(4);
+  }
+}).catch((error) => {
+  console.error(error);
+  process.exit(5);
+});
+'
+
+# A imagem Supabase Postgres fornece Vault e Wrappers. O Studio exige Wrappers
+# >= 0.5.6 para reconhecer a integracao S3 Vectors.
+echo "▶ Instalando/verificando Vault e Wrappers em $POSTGRES_DATABASE..."
+docker exec -i supabase-db psql \
+  -X -q -v ON_ERROR_STOP=1 \
+  -U "$POSTGRES_USER" \
+  -d "$POSTGRES_DATABASE" <<'SQL'
+CREATE SCHEMA IF NOT EXISTS extensions;
+CREATE EXTENSION IF NOT EXISTS supabase_vault CASCADE;
+CREATE EXTENSION IF NOT EXISTS wrappers WITH SCHEMA extensions;
+SQL
+
+WRAPPERS_VERSION="$(
+  docker exec supabase-db psql \
+    -X -q -v ON_ERROR_STOP=1 \
+    -U "$POSTGRES_USER" \
+    -d "$POSTGRES_DATABASE" \
+    -tAc "SELECT extversion FROM pg_extension WHERE extname = 'wrappers'"
+)"
+[[ -n "$WRAPPERS_VERSION" ]] || fail "A extensao wrappers nao foi instalada"
+
+python3 - "$WRAPPERS_VERSION" <<'PY'
+import re
+import sys
+
+version = sys.argv[1].strip()
+match = re.match(r"^(\d+)\.(\d+)\.(\d+)", version)
+if not match:
+    raise SystemExit(f"versao Wrappers invalida: {version}")
+parts = tuple(map(int, match.groups()))
+if parts < (0, 5, 6):
+    raise SystemExit(
+        f"Wrappers >= 0.5.6 obrigatorio para S3 Vectors; encontrado {version}"
+    )
+PY
+
+# Os segredos ficam criptografados no Vault. O servidor FDW referencia apenas os
+# UUIDs do Vault, exatamente como o gerador SQL do Studio oficial.
+echo "▶ Configurando o S3 Vectors Wrapper '$WRAPPER_NAME'..."
+docker exec -i \
+  -e SETUP_WRAPPER_NAME="$WRAPPER_NAME" \
+  -e SETUP_SERVER_NAME="$SERVER_NAME" \
+  -e SETUP_ACCESS_SECRET_NAME="$ACCESS_SECRET_NAME" \
+  -e SETUP_SECRET_SECRET_NAME="$SECRET_SECRET_NAME" \
+  -e SETUP_S3_ACCESS_KEY="$S3_PROTOCOL_ACCESS_KEY_ID" \
+  -e SETUP_S3_SECRET_KEY="$S3_PROTOCOL_ACCESS_KEY_SECRET" \
+  -e SETUP_REGION="$STORAGE_REGION" \
+  -e SETUP_ENDPOINT="$VECTOR_ENDPOINT" \
+  supabase-db psql \
+    -X -q -v ON_ERROR_STOP=1 \
+    -U "$POSTGRES_USER" \
+    -d "$POSTGRES_DATABASE" <<'SQL'
+\getenv wrapper_name SETUP_WRAPPER_NAME
+\getenv server_name SETUP_SERVER_NAME
+\getenv access_secret_name SETUP_ACCESS_SECRET_NAME
+\getenv secret_secret_name SETUP_SECRET_SECRET_NAME
+\getenv s3_access_key SETUP_S3_ACCESS_KEY
+\getenv s3_secret_key SETUP_S3_SECRET_KEY
+\getenv aws_region SETUP_REGION
+\getenv endpoint_url SETUP_ENDPOINT
+
+BEGIN;
+SET LOCAL log_statement = 'none';
+
+CREATE TEMP TABLE vector_wrapper_setup_params (
+  wrapper_name text NOT NULL,
+  server_name text NOT NULL,
+  access_secret_name text NOT NULL,
+  secret_secret_name text NOT NULL,
+  s3_access_key text NOT NULL,
+  s3_secret_key text NOT NULL,
+  aws_region text NOT NULL,
+  endpoint_url text NOT NULL
+) ON COMMIT DROP;
+
+INSERT INTO vector_wrapper_setup_params VALUES (
+  :'wrapper_name', :'server_name',
+  :'access_secret_name', :'secret_secret_name',
+  :'s3_access_key', :'s3_secret_key',
+  :'aws_region', :'endpoint_url'
+);
+
+DO $setup$
+DECLARE
+  cfg record;
+  access_secret_id uuid;
+  secret_secret_id uuid;
+  handler_schema text;
+  validator_schema text;
+  existing_handler text;
+  existing_server_fdw text;
+  option_name text;
+  option_value text;
+BEGIN
+  SELECT * INTO STRICT cfg FROM vector_wrapper_setup_params;
+
+  SELECT id INTO access_secret_id
+  FROM vault.secrets
+  WHERE name = cfg.access_secret_name;
+
+  IF access_secret_id IS NULL THEN
+    access_secret_id := vault.create_secret(
+      cfg.s3_access_key,
+      cfg.access_secret_name,
+      'S3 Vectors access key for ' || cfg.wrapper_name
+    );
+  ELSE
+    PERFORM vault.update_secret(
+      access_secret_id,
+      cfg.s3_access_key,
+      cfg.access_secret_name,
+      'S3 Vectors access key for ' || cfg.wrapper_name
+    );
+  END IF;
+
+  SELECT id INTO secret_secret_id
+  FROM vault.secrets
+  WHERE name = cfg.secret_secret_name;
+
+  IF secret_secret_id IS NULL THEN
+    secret_secret_id := vault.create_secret(
+      cfg.s3_secret_key,
+      cfg.secret_secret_name,
+      'S3 Vectors secret key for ' || cfg.wrapper_name
+    );
+  ELSE
+    PERFORM vault.update_secret(
+      secret_secret_id,
+      cfg.s3_secret_key,
+      cfg.secret_secret_name,
+      'S3 Vectors secret key for ' || cfg.wrapper_name
+    );
+  END IF;
+
+  SELECT n.nspname INTO handler_schema
+  FROM pg_proc p
+  JOIN pg_namespace n ON n.oid = p.pronamespace
+  WHERE p.proname = 's3_vectors_fdw_handler'
+  ORDER BY (n.nspname = 'extensions') DESC, n.nspname
+  LIMIT 1;
+
+  SELECT n.nspname INTO validator_schema
+  FROM pg_proc p
+  JOIN pg_namespace n ON n.oid = p.pronamespace
+  WHERE p.proname = 's3_vectors_fdw_validator'
+  ORDER BY (n.nspname = 'extensions') DESC, n.nspname
+  LIMIT 1;
+
+  IF handler_schema IS NULL OR validator_schema IS NULL THEN
+    RAISE EXCEPTION
+      'Wrappers % nao fornece s3_vectors_fdw_handler/validator',
+      (SELECT extversion FROM pg_extension WHERE extname = 'wrappers');
+  END IF;
+
+  SELECT p.proname INTO existing_handler
+  FROM pg_foreign_data_wrapper w
+  LEFT JOIN pg_proc p ON p.oid = w.fdwhandler
+  WHERE w.fdwname = cfg.wrapper_name;
+
+  IF existing_handler IS NULL THEN
+    EXECUTE format(
+      'CREATE FOREIGN DATA WRAPPER %I HANDLER %I.%I VALIDATOR %I.%I',
+      cfg.wrapper_name,
+      handler_schema,
+      's3_vectors_fdw_handler',
+      validator_schema,
+      's3_vectors_fdw_validator'
+    );
+  ELSIF existing_handler <> 's3_vectors_fdw_handler' THEN
+    RAISE EXCEPTION
+      'FDW % ja existe com handler inesperado %',
+      cfg.wrapper_name,
+      existing_handler;
+  END IF;
+
+  SELECT w.fdwname INTO existing_server_fdw
+  FROM pg_foreign_server s
+  JOIN pg_foreign_data_wrapper w ON w.oid = s.srvfdw
+  WHERE s.srvname = cfg.server_name;
+
+  IF existing_server_fdw IS NULL THEN
+    EXECUTE format(
+      'CREATE SERVER %I FOREIGN DATA WRAPPER %I OPTIONS (' ||
+      'vault_access_key_id %L, vault_secret_access_key %L, ' ||
+      'aws_region %L, endpoint_url %L)',
+      cfg.server_name,
+      cfg.wrapper_name,
+      access_secret_id::text,
+      secret_secret_id::text,
+      cfg.aws_region,
+      cfg.endpoint_url
+    );
+  ELSIF existing_server_fdw <> cfg.wrapper_name THEN
+    RAISE EXCEPTION
+      'Servidor % pertence ao FDW %, esperado %',
+      cfg.server_name,
+      existing_server_fdw,
+      cfg.wrapper_name;
+  ELSE
+    FOREACH option_name IN ARRAY ARRAY[
+      'vault_access_key_id',
+      'vault_secret_access_key',
+      'aws_region',
+      'endpoint_url'
+    ]
+    LOOP
+      option_value := CASE option_name
+        WHEN 'vault_access_key_id' THEN access_secret_id::text
+        WHEN 'vault_secret_access_key' THEN secret_secret_id::text
+        WHEN 'aws_region' THEN cfg.aws_region
+        WHEN 'endpoint_url' THEN cfg.endpoint_url
+      END;
+
+      IF EXISTS (
+        SELECT 1
+        FROM pg_foreign_server s,
+             LATERAL unnest(COALESCE(s.srvoptions, ARRAY[]::text[])) opt
+        WHERE s.srvname = cfg.server_name
+          AND split_part(opt, '=', 1) = option_name
+      ) THEN
+        EXECUTE format(
+          'ALTER SERVER %I OPTIONS (SET %I %L)',
+          cfg.server_name,
+          option_name,
+          option_value
+        );
+      ELSE
+        EXECUTE format(
+          'ALTER SERVER %I OPTIONS (ADD %I %L)',
+          cfg.server_name,
+          option_name,
+          option_value
+        );
+      END IF;
+    END LOOP;
+  END IF;
+END
+$setup$;
+
+COMMIT;
+SQL
+
+# IMPORT FOREIGN SCHEMA e a operacao real usada pelo Studio para expor os
+# indexes como tabelas. A sonda cria um schema temporario, consulta o Storage
+# usando SigV4 e o remove logo depois; nenhuma tabela do usuario e alterada.
+PROBE_SCHEMA="vector_wrapper_probe_${PROJECT_ID}_$$"
+PROBE_SCHEMA="${PROBE_SCHEMA:0:63}"
+
+echo "▶ Testando o wrapper contra $VECTOR_ENDPOINT..."
+if python3 - "$WRAPPERS_VERSION" <<'PY'
+import re
+import sys
+m = re.match(r"^(\d+)\.(\d+)\.(\d+)", sys.argv[1])
+raise SystemExit(0 if m and tuple(map(int, m.groups())) >= (0, 5, 7) else 1)
+PY
+then
+  docker exec -i \
+    -e PROBE_SCHEMA="$PROBE_SCHEMA" \
+    -e PROBE_SERVER="$SERVER_NAME" \
+    -e PROBE_BUCKET="$BUCKET_NAME" \
+    supabase-db psql \
+      -X -q -v ON_ERROR_STOP=1 \
+      -U "$POSTGRES_USER" \
+      -d "$POSTGRES_DATABASE" <<'SQL'
+\getenv probe_schema PROBE_SCHEMA
+\getenv probe_server PROBE_SERVER
+\getenv probe_bucket PROBE_BUCKET
+CREATE SCHEMA :"probe_schema";
+IMPORT FOREIGN SCHEMA :"probe_bucket"
+  FROM SERVER :"probe_server"
+  INTO :"probe_schema"
+  OPTIONS (strict 'true');
+DROP SCHEMA :"probe_schema" CASCADE;
+SQL
+else
+  docker exec -i \
+    -e PROBE_SCHEMA="$PROBE_SCHEMA" \
+    -e PROBE_SERVER="$SERVER_NAME" \
+    -e PROBE_BUCKET="$BUCKET_NAME" \
+    supabase-db psql \
+      -X -q -v ON_ERROR_STOP=1 \
+      -U "$POSTGRES_USER" \
+      -d "$POSTGRES_DATABASE" <<'SQL'
+\getenv probe_schema PROBE_SCHEMA
+\getenv probe_server PROBE_SERVER
+\getenv probe_bucket PROBE_BUCKET
+CREATE SCHEMA :"probe_schema";
+IMPORT FOREIGN SCHEMA :"probe_schema"
+  FROM SERVER :"probe_server"
+  INTO :"probe_schema"
+  OPTIONS (bucket_name :'probe_bucket', strict 'true');
+DROP SCHEMA :"probe_schema" CASCADE;
+SQL
+fi
+
+echo "✅ Integracao S3 Vectors Wrapper configurada para '$BUCKET_NAME'."
+echo "   FDW:      $WRAPPER_NAME"
+echo "   Servidor: $SERVER_NAME"
+echo "   Endpoint: $VECTOR_ENDPOINT"

--- a/tests/smoke/test_storage_vector_wrapper_contract.py
+++ b/tests/smoke/test_storage_vector_wrapper_contract.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+import pathlib
+import subprocess
+import unittest
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+ENV_TEMPLATE = ROOT / "servidor/generateProject/.envtemplate"
+ENABLE_SCRIPT = ROOT / "servidor/generateProject/enable_vector_storage.sh"
+WRAPPER_SCRIPT = ROOT / "servidor/generateProject/setup_vector_bucket_wrapper.sh"
+
+
+class StorageVectorWrapperContractTests(unittest.TestCase):
+    def test_project_template_reserves_sigv4_credentials(self) -> None:
+        env = ENV_TEMPLATE.read_text(encoding="utf-8")
+
+        self.assertIn("S3_PROTOCOL_ENABLED=true", env)
+        self.assertIn("S3_PROTOCOL_ACCESS_KEY_ID=", env)
+        self.assertIn("S3_PROTOCOL_ACCESS_KEY_SECRET=", env)
+
+    def test_vector_bootstrap_generates_per_project_sigv4_keys(self) -> None:
+        script = ENABLE_SCRIPT.read_text(encoding="utf-8")
+
+        self.assertIn("openssl rand -hex 16", script)
+        self.assertIn("openssl rand -hex 32", script)
+        self.assertIn('"S3_PROTOCOL_ENABLED": "true"', script)
+        self.assertIn('"S3_PROTOCOL_ACCESS_KEY_ID": sys.argv[2]', script)
+        self.assertIn('"S3_PROTOCOL_ACCESS_KEY_SECRET": sys.argv[3]', script)
+        self.assertIn("Credenciais SigV4 por projeto instaladas sem serem exibidas", script)
+        self.assertNotIn('echo "$S3_PROTOCOL_ACCESS_KEY_SECRET"', script)
+
+    def test_wrapper_matches_the_studio_naming_and_extension_contract(self) -> None:
+        script = WRAPPER_SCRIPT.read_text(encoding="utf-8")
+
+        self.assertIn('print(f"{value}_fdw")', script)
+        self.assertIn('print(f"{value}_fdw_server")', script)
+        self.assertIn("Wrappers >= 0.5.6 obrigatorio", script)
+        self.assertIn("s3_vectors_fdw_handler", script)
+        self.assertIn("s3_vectors_fdw_validator", script)
+
+    def test_wrapper_uses_vault_and_the_tenant_internal_endpoint(self) -> None:
+        script = WRAPPER_SCRIPT.read_text(encoding="utf-8")
+
+        self.assertIn("CREATE EXTENSION IF NOT EXISTS supabase_vault CASCADE", script)
+        self.assertIn("vault.create_secret", script)
+        self.assertIn("vault.update_secret", script)
+        self.assertIn('VECTOR_ENDPOINT="http://${STORAGE_CONTAINER}:5000/vector"', script)
+        self.assertIn("vault_access_key_id", script)
+        self.assertIn("vault_secret_access_key", script)
+        self.assertNotIn("host.docker.internal", script)
+
+    def test_wrapper_validates_real_bucket_and_import_foreign_schema(self) -> None:
+        script = WRAPPER_SCRIPT.read_text(encoding="utf-8")
+
+        self.assertIn("/vector/GetVectorBucket", script)
+        self.assertIn("IMPORT FOREIGN SCHEMA", script)
+        self.assertIn("OPTIONS (strict 'true')", script)
+        self.assertNotIn('indexes = {}', script)
+        self.assertNotIn('vectorBuckets = {}', script)
+
+    def test_shell_syntax(self) -> None:
+        for script in (ENABLE_SCRIPT, WRAPPER_SCRIPT):
+            subprocess.run(["bash", "-n", str(script)], check=True)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Diagnóstico

O backend de Vector Buckets já está funcionando com pgvector. A mensagem exibida na tela:

```text
Missing integration
The S3 Vectors Wrapper integration is required in order to query vector tables.
```

não indica falha no bucket nem no endpoint de índices. Ela significa que o banco do projeto ainda não possui o FDW que permite consultar os indexes vetoriais a partir do Postgres.

No Studio oficial, o botão **Install wrapper** pressupõe uma instalação self-hosted simples, com um único Studio e um único Storage. Ele:

1. lê `S3_PROTOCOL_ACCESS_KEY_ID` e `S3_PROTOCOL_ACCESS_KEY_SECRET` de `/api/get-s3-keys`;
2. grava essas credenciais no Vault;
3. cria um FDW chamado `<bucket_em_snake_case>_fdw`;
4. cria o servidor `<wrapper>_server`;
5. aponta o servidor para `/storage/v1/vector`.

Esse fluxo não pode usar um único par estático no Studio deste projeto, porque o Studio é compartilhado por vários tenants. Também não deve usar `host.docker.internal`, pois cada Storage já possui um endereço interno isolado na rede Docker.

## Implementação

### Credenciais SigV4 por projeto

`enable_vector_storage.sh` agora gera e preserva um par exclusivo por projeto:

```env
S3_PROTOCOL_ENABLED=true
S3_PROTOCOL_ACCESS_KEY_ID=<32 caracteres hex>
S3_PROTOCOL_ACCESS_KEY_SECRET=<64 caracteres hex>
```

Essas credenciais:

- são diferentes das chaves JWT `anon` e `service_role`;
- autenticam o protocolo S3 Vectors com AWS Signature V4;
- ficam no `.env` do projeto com modo `0600`;
- são injetadas somente no Storage daquele tenant;
- nunca são impressas pelo script.

### Setup por Vector Bucket

Adiciona:

```text
servidor/generateProject/setup_vector_bucket_wrapper.sh
```

Uso:

```bash
setup_vector_bucket_wrapper.sh <project_id> <vector_bucket_name>
```

O script:

1. garante pgvector, migrations vetoriais e credenciais SigV4;
2. confirma que o bucket existe chamando `GetVectorBucket` no Storage API real;
3. instala/verifica `supabase_vault` e `wrappers`;
4. exige Wrappers `>= 0.5.6`, mesma versão mínima do Studio;
5. grava access key e secret key criptografadas no Vault;
6. cria idempotentemente:
   - `<bucket>_fdw` com `s3_vectors_fdw_handler`;
   - `<bucket>_fdw_server` com `s3_vectors_fdw_validator`;
7. aponta diretamente para o Storage do tenant:

```text
http://supabase-storage-<project>:5000/vector
```

8. executa uma sonda real com `IMPORT FOREIGN SCHEMA` e remove o schema temporário em seguida.

O servidor FDW guarda somente os UUIDs das entradas do Vault, não as credenciais em texto claro.

## Por que não usar o botão oficial diretamente

A implementação oficial do Studio self-hosted busca chaves estáticas no ambiente do próprio Studio e calcula um endpoint por porta do host. Neste projeto:

- o Studio é compartilhado;
- as credenciais precisam ser isoladas por projeto;
- os Storage APIs não devem compartilhar uma chave SigV4;
- o endpoint correto já está disponível por DNS interno da rede Docker.

Criar o FDW pelo script reproduz o contrato oficial sem expor credenciais de outro tenant e sem depender do navegador para transportar segredos.

## Aplicação no projeto atual

Após o merge:

```bash
cd /home/gustavo/supabase-multitenant-2
git pull --ff-only origin main

chmod +x servidor/generateProject/enable_vector_storage.sh
chmod +x servidor/generateProject/setup_vector_bucket_wrapper.sh

servidor/generateProject/setup_vector_bucket_wrapper.sh meu_projeto rrrr
```

Depois, atualize a tela. O Studio procura especificamente por `rrrr_fdw`; quando ele existir, o aviso **Missing integration** deve desaparecer.

Ao escolher **Query from Postgres**, o Studio poderá criar um schema e executar `IMPORT FOREIGN SCHEMA` para expor os indexes do bucket como foreign tables.

## Segurança

- não há resposta vazia fabricada;
- não há fallback que converta erro em sucesso;
- as chaves SigV4 não são registradas nos logs;
- o `.env` permanece `0600`;
- o Vault armazena a cópia usada pelo FDW;
- o endpoint é interno e específico do tenant;
- o script falha se bucket, extensão, versão, handler, autenticação ou importação estiverem incorretos.

## Testes

Foram adicionados testes de contrato para:

- variáveis S3 Protocol no template;
- geração de chaves 32/64 hex por projeto;
- ausência de impressão do secret;
- versão mínima Wrappers 0.5.6;
- nomes exatos reconhecidos pelo Studio;
- uso de Vault;
- endpoint interno por tenant;
- validação real com `GetVectorBucket` e `IMPORT FOREIGN SCHEMA`;
- sintaxe dos scripts com `bash -n`.